### PR TITLE
refactor: re-use UpsunClient across commands

### DIFF
--- a/upsun-mcp/src/command/activity.ts
+++ b/upsun-mcp/src/command/activity.ts
@@ -1,4 +1,3 @@
-import { UpsunClient, UpsunConfig } from "upsun-sdk-node";
 import { McpAdapter } from "../core/adapter.js";
 import { z } from "zod";
 
@@ -14,8 +13,7 @@ export function registerActivity(adapter: McpAdapter): void {
             activity_id: z.string()
         },
         async ({ project_id, activity_id }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.activity.cancel(project_id, activity_id);
+            const result = await adapter.client.activity.cancel(project_id, activity_id);
 
             return {
                 content: [{
@@ -34,8 +32,7 @@ export function registerActivity(adapter: McpAdapter): void {
             activity_id: z.string()
         },
         async ({ project_id, activity_id }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.activity.get(project_id, activity_id);
+            const result = await adapter.client.activity.get(project_id, activity_id);
 
             return {
                 content: [{
@@ -53,8 +50,7 @@ export function registerActivity(adapter: McpAdapter): void {
             project_id: z.string()
         },
         async ({ project_id }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.activity.list(project_id);
+            const result = await adapter.client.activity.list(project_id);
 
             return {
                 content: [{
@@ -73,8 +69,7 @@ export function registerActivity(adapter: McpAdapter): void {
             activity_id: z.string()
         },
         async ({ project_id, activity_id }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            //const result = await client.activity.log(project_id, activity_id);
+            //const result = await adapter.client.activity.log(project_id, activity_id);
             const result = "Not implemented";
 
             return {

--- a/upsun-mcp/src/command/environment.ts
+++ b/upsun-mcp/src/command/environment.ts
@@ -1,4 +1,3 @@
-import { UpsunClient, UpsunConfig } from "upsun-sdk-node";
 import { McpAdapter } from "../core/adapter.js";
 import { z } from "zod";
 
@@ -14,8 +13,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.activate(project_id, environment_name);
+            const result = await adapter.client.environment.activate(project_id, environment_name);
 
             return {
                 content: [{
@@ -34,8 +32,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            //const result = await client.environment.delete(project_id, environment_name);
+            //const result = await adapter.client.environment.delete(project_id, environment_name);
             const result = "Not implemented (too dangerous)";
 
             return {
@@ -55,8 +52,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.info(project_id, environment_name);
+            const result = await adapter.client.environment.info(project_id, environment_name);
 
             return {
                 content: [{
@@ -74,8 +70,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             project_id: z.string()
         },
         async ({ project_id }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.list(project_id);
+            const result = await adapter.client.environment.list(project_id);
 
             return {
                 content: [{
@@ -114,8 +109,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.merge(project_id, environment_name);
+            const result = await adapter.client.environment.merge(project_id, environment_name);
 
             return {
                 content: [{
@@ -134,8 +128,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.pause(project_id, environment_name);
+            const result = await adapter.client.environment.pause(project_id, environment_name);
 
             return {
                 content: [{
@@ -155,8 +148,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             application_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.redeploy(project_id, environment_name);
+            const result = await adapter.client.environment.redeploy(project_id, environment_name);
 
             return {
                 content: [{
@@ -175,8 +167,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            const result = await client.environment.resume(project_id, environment_name);
+            const result = await adapter.client.environment.resume(project_id, environment_name);
 
             return {
                 content: [{
@@ -195,8 +186,7 @@ export function registerEnvironment(adapter: McpAdapter): void {  // , cliProvid
             environment_name: z.string()
         },
         async ({ project_id, environment_name }) => {
-            const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-            //const result = await client.environment.url(project_id, environment_name);
+            //const result = await adapter.client.environment.url(project_id, environment_name);
             const result = "Not implemented (too dangerous)";
 
             return {

--- a/upsun-mcp/src/command/organization.ts
+++ b/upsun-mcp/src/command/organization.ts
@@ -1,4 +1,3 @@
-import { UpsunClient, UpsunConfig } from "upsun-sdk-node";
 import { McpAdapter } from "../core/adapter.js";
 import { z } from "zod";
 
@@ -13,8 +12,7 @@ export function registerOrganization(adapter: McpAdapter): void {
       organization_name: z.string()
     },
     async ({ organization_name }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = await client.organization.create(organization_name);
+      const result = await adapter.client.organization.create(organization_name);
 
       return {
         content: [{
@@ -32,8 +30,7 @@ export function registerOrganization(adapter: McpAdapter): void {
       organization_id: z.string()
     },
     async ({ organization_id }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      //const result = await client.organization.delete(organization_id);
+      //const result = await adapter.client.organization.delete(organization_id);
       const result = "Not implemented (too dangerous)";
 
       return {
@@ -52,8 +49,7 @@ export function registerOrganization(adapter: McpAdapter): void {
       organization_id: z.string()
     },
     async ({ organization_id }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = await client.organization.info(organization_id);
+      const result = await adapter.client.organization.info(organization_id);
 
       return {
         content: [{
@@ -71,8 +67,7 @@ export function registerOrganization(adapter: McpAdapter): void {
       
     },
     async ({ }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = await client.organization.list();
+      const result = await adapter.client.organization.list();
 
       return {
         content: [{

--- a/upsun-mcp/src/command/project.ts
+++ b/upsun-mcp/src/command/project.ts
@@ -1,4 +1,3 @@
-import { UpsunClient, UpsunConfig } from "upsun-sdk-node";
 import { McpAdapter } from "../core/adapter.js";
 import { z } from "zod";
 
@@ -16,8 +15,7 @@ export function registerProject(adapter: McpAdapter): void {  // , cliProvider: 
       default_branch: z.string().default("main").optional()
     },
     async ({ organization_id, region, name, default_branch }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = await client.project.create(organization_id, name); // region, default_branch
+      const result = await adapter.client.project.create(organization_id, name); // region, default_branch
 
       return {
         content: [{
@@ -35,8 +33,7 @@ export function registerProject(adapter: McpAdapter): void {  // , cliProvider: 
       project_id: z.string(),
     },
     async ({ project_id }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      //const result = await client.project.delete(project_id);
+      //const result = await adapter.client.project.delete(project_id);
       const result = "Not implemented (too dangerous)";
 
       return {
@@ -53,8 +50,7 @@ export function registerProject(adapter: McpAdapter): void {  // , cliProvider: 
     "Get information of upsun project",
     { project_id: z.string() },
     async ({ project_id }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const project = await client.project.info(project_id);
+      const project = await adapter.client.project.info(project_id);
 
       return {
         content: [{
@@ -70,8 +66,7 @@ export function registerProject(adapter: McpAdapter): void {  // , cliProvider: 
     "List all upsun projects",             // Text to indicate on LLM target and call
     { organization_id: z.string() },          // Parameter of this tool
     async ({ organization_id }) => {          // Main function
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const projects = await client.project.list(organization_id);
+      const projects = await adapter.client.project.list(organization_id);
 
       return {
         content: [{

--- a/upsun-mcp/src/command/route.ts
+++ b/upsun-mcp/src/command/route.ts
@@ -1,9 +1,8 @@
-import { UpsunClient, UpsunConfig } from "upsun-sdk-node";
 import { McpAdapter } from "../core/adapter.js";
 import { z } from "zod";
 
 
-export function registerRoute(adapter: McpAdapter): void {  // , cliProvider: Client
+export function registerRoute(adapter: McpAdapter): void {
   console.log(`Register Route Handlers`);
 
   adapter.server.tool(
@@ -15,8 +14,7 @@ export function registerRoute(adapter: McpAdapter): void {  // , cliProvider: Cl
       route_id: z.string().optional()
     },
     async ({ project_id,environment_name, route_id }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = (await client.route.get(project_id, environment_name, route_id || ''));
+      const result = (await adapter.client.route.get(project_id, environment_name, route_id || ''));
 
       return {
         content: [{
@@ -35,8 +33,7 @@ export function registerRoute(adapter: McpAdapter): void {  // , cliProvider: Cl
       environment_name: z.string()
     },
     async ({ project_id,environment_name }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = (await client.route.list(project_id, environment_name));
+      const result = await adapter.client.route.list(project_id, environment_name);
 
       return {
         content: [{
@@ -54,8 +51,7 @@ export function registerRoute(adapter: McpAdapter): void {  // , cliProvider: Cl
       project_id: z.string()
     },
     async ({ project_id }) => {
-      const client = new UpsunClient({ apiKey: adapter.apikey } as UpsunConfig);
-      const result = (await client.route.web(project_id)).ui;
+      const result = (await adapter.client.route.web(project_id)).ui;
 
       return {
         content: [{

--- a/upsun-mcp/src/core/adapter.ts
+++ b/upsun-mcp/src/core/adapter.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { UpsunClient } from "upsun-sdk-node";
 
 /**
  * McpAdapter interface
@@ -10,6 +11,6 @@ import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 export interface McpAdapter {
   apikey: string;
   readonly server : McpServer;
-  
+  readonly client: UpsunClient;
   connect(transport: Transport): Promise<void>;
 }

--- a/upsun-mcp/src/mcpUpsun.ts
+++ b/upsun-mcp/src/mcpUpsun.ts
@@ -1,6 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { UpsunClient, UpsunConfig } from "upsun-sdk-node";
 
+import * as pjson from '../package.json' with { type: 'json' };
 import { McpAdapter } from "./core/adapter.js";
 import {
   registerActivity,
@@ -17,13 +19,16 @@ import {
 export class UpsunMcpServer implements McpAdapter {
 
   public readonly apikey!: string;
+  public readonly client!: UpsunClient;
 
   constructor(
     public readonly server: McpServer = new McpServer({
       name: "upsun-server",
-      version: "0.1.0"
+      version: pjson.default.version
     }),
   ) {
+    this.client = new UpsunClient({ apiKey: this.apikey } as UpsunConfig);
+
     registerActivity(this);
     registerEnvironment(this);
     registerOrganization(this);

--- a/upsun-mcp/tsconfig.json
+++ b/upsun-mcp/tsconfig.json
@@ -11,11 +11,16 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "resolveJsonModule": true
   },
   "ts-node": {
     "esm": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
We're currently declaring a new instance of `UpsunClient` each time a tool is called.
We're now re-using one instance during the runtime