### PR TITLE
fix: use listCurrentUserOrgs for list-organization tool

### DIFF
--- a/upsun-mcp/src/command/organization.ts
+++ b/upsun-mcp/src/command/organization.ts
@@ -115,7 +115,7 @@ export function registerOrganization(adapter: McpAdapter): void {
 
   /**
    * Tool: list-organization
-   * Lists all organizations the current user has access to.
+   * Lists all organizations the current user is a member of.
    *
    * Returns an array of organizations with basic information such as
    * organization ID, name, owner, and number of projects.

--- a/upsun-mcp/src/command/organization.ts
+++ b/upsun-mcp/src/command/organization.ts
@@ -1,11 +1,7 @@
 /**
  * @fileoverview Organization management command module for Upsun MCP server.
- * 
- * This module provides MCP too    async () => {
-      const result = await adapter.client.organizations.list();
-
-      return Response.json(result);
-    }r managing Upsun organizations, which are
+ *
+ * This module provides MCP tools for managing Upsun organizations, which are
  * top-level entities that contain projects and manage billing, user access,
  * and resource allocation.
  */
@@ -135,7 +131,7 @@ export function registerOrganization(adapter: McpAdapter): void {
     },
     ToolWrapper.trace('list-organization', async () => {
       log.debug(`List all my organizations`);
-      const result = await adapter.client.organizations.list();
+      const result = await adapter.client.organizations.listCurrentUserOrgs();
 
       return Response.json(result);
     })

--- a/upsun-mcp/test/command/organization.test.ts
+++ b/upsun-mcp/test/command/organization.test.ts
@@ -20,7 +20,7 @@ const mockOrganizationsApi = {
   create: jest.fn(),
   delete: jest.fn(),
   info: jest.fn(),
-  list: jest.fn(),
+  listCurrentUserOrgs: jest.fn(),
 };
 
 const mockClient: { organizations: any } = {
@@ -100,7 +100,7 @@ describe('Organization Command Module', () => {
     mockClient.organizations.create.mockResolvedValue(mockCreateResult);
     mockClient.organizations.delete.mockResolvedValue(mockDeleteResult);
     mockClient.organizations.info.mockResolvedValue(mockOrganization);
-    mockClient.organizations.list.mockResolvedValue(mockOrganizationList);
+    mockClient.organizations.listCurrentUserOrgs.mockResolvedValue(mockOrganizationList);
   });
 
   afterEach(() => {
@@ -371,7 +371,7 @@ describe('Organization Command Module', () => {
 
       const result = await callback(params);
 
-      expect(mockClient.organizations.list).toHaveBeenCalledWith();
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith();
       expect(result).toEqual({
         content: [
           {
@@ -384,13 +384,13 @@ describe('Organization Command Module', () => {
 
     it('should handle empty organization list', async () => {
       const callback = toolCallbacks['list-organization'];
-      mockClient.organizations.list.mockResolvedValue([]);
+      mockClient.organizations.listCurrentUserOrgs.mockResolvedValue([]);
 
       const params = {};
 
       const result = await callback(params);
 
-      expect(mockClient.organizations.list).toHaveBeenCalledWith();
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith();
       expect(result).toEqual({
         content: [
           {
@@ -404,12 +404,12 @@ describe('Organization Command Module', () => {
     it('should handle list organizations errors', async () => {
       const callback = toolCallbacks['list-organization'];
       const errorMessage = 'Authentication failed';
-      mockClient.organizations.list.mockRejectedValue(new Error(errorMessage));
+      mockClient.organizations.listCurrentUserOrgs.mockRejectedValue(new Error(errorMessage));
 
       const params = {};
 
       await expect(callback(params)).rejects.toThrow(errorMessage);
-      expect(mockClient.organizations.list).toHaveBeenCalledWith();
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith();
     });
 
     it('should handle large organization lists', async () => {
@@ -423,7 +423,7 @@ describe('Organization Command Module', () => {
         projects_count: i % 10,
         members_count: (i % 5) + 1,
       }));
-      mockClient.organizations.list.mockResolvedValue(largeOrganizationList);
+      mockClient.organizations.listCurrentUserOrgs.mockResolvedValue(largeOrganizationList);
 
       const params = {};
 
@@ -478,7 +478,9 @@ describe('Organization Command Module', () => {
 
     it('should handle API rate limiting', async () => {
       const callback = toolCallbacks['list-organization'];
-      mockClient.organizations.list.mockRejectedValue(new Error('Rate limit exceeded'));
+      mockClient.organizations.listCurrentUserOrgs.mockRejectedValue(
+        new Error('Rate limit exceeded')
+      );
 
       const params = {};
 


### PR DESCRIPTION
## Summary

- `list-organization` now calls `listCurrentUserOrgs()` instead of `list()`, so it returns only organizations the authenticated user is a member of rather than all visible organizations.
- Fix corrupted `@fileoverview` comment in `organization.ts`.
- Remove unused `list` mock from organization tests.

Closes MCP-7

## Test plan

- [x] `npm run build` compiles without errors
- [x] All 446 tests pass (`npm test`)
- [x] `npm run lint` and `npm run prettier:check` pass
- [x] Manual: invoke `list-organization` and confirm it returns only the user's own orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)