### PR TITLE
fix: make OpenTelemetry safe for production deployment

### DIFF
--- a/upsun-mcp/OPENTELEMETRY.md
+++ b/upsun-mcp/OPENTELEMETRY.md
@@ -19,7 +19,7 @@ The Upsun MCP Server integrates OpenTelemetry for distributed tracing, providing
 
 | Variable             | Description                                  | Default            | Values                      |
 | -------------------- | -------------------------------------------- | ------------------ | --------------------------- |
-| `OTEL_ENABLED`       | Enable/disable OpenTelemetry tracing         | `true`             | `true`, `false`             |
+| `OTEL_ENABLED`       | Enable/disable OpenTelemetry tracing         | `false`            | `true`, `false`             |
 | `OTEL_SAMPLING_RATE` | Percentage of traces to capture (0.0 to 1.0) | `1.0`              | `0.0` - `1.0`               |
 | `OTEL_EXPORTER_TYPE` | Type of trace exporter to use                | `console`          | `console`, `otlp`, `none`   |
 | `OTEL_SERVICE_NAME`  | Service name in traces                       | `upsun-mcp-server` | Any string                  |
@@ -136,14 +136,14 @@ OTEL_EXPORTER_ENDPOINT=https://your-collector.example.com/v1/traces
 
 ### None Exporter
 
-Traces are collected but not exported:
+Tracing is disabled:
 
 ```bash
 OTEL_EXPORTER_TYPE=none
 ```
 
 - Useful for testing without overhead
-- Tracing code runs but doesn't send data
+- No traces are collected or exported
 
 ## Verification
 

--- a/upsun-mcp/src/core/config.ts
+++ b/upsun-mcp/src/core/config.ts
@@ -225,7 +225,7 @@ export const storageConfig = {
  */
 export const otelConfig = {
   /** Enable or disable OpenTelemetry distributed tracing */
-  enabled: parseBoolean(process.env.OTEL_ENABLED, true),
+  enabled: parseBoolean(process.env.OTEL_ENABLED, false),
 
   /** Sampling rate for traces (0.0 to 1.0) */
   samplingRate: parseNumber(process.env.OTEL_SAMPLING_RATE, 1.0, 0.0, 1.0),

--- a/upsun-mcp/src/core/telemetry.ts
+++ b/upsun-mcp/src/core/telemetry.ts
@@ -56,17 +56,25 @@ function getSpanExporter(): ConsoleSpanExporter | OTLPTraceExporter {
 }
 
 /**
- * Initialize OpenTelemetry SDK
+ * Initialize OpenTelemetry SDK.
  *
  * Sets up distributed tracing with configured sampling rate, exporter,
  * and automatic instrumentation for Node.js libraries (HTTP, Express, etc.)
  *
- * @returns Promise that resolves when initialization is complete
+ * If initialization fails the error is logged, any partially-initialized SDK
+ * is cleaned up, and the function resolves normally so the server can
+ * continue without tracing. Use {@link isTelemetryEnabled} to check whether
+ * initialization succeeded.
+ *
+ * @returns Promise that resolves when initialization is complete (or has
+ *   failed gracefully).
  *
  * @example
  * ```typescript
  * await initTelemetry();
- * // Telemetry is now active
+ * if (isTelemetryEnabled()) {
+ *   // Tracing is active.
+ * }
  * ```
  */
 export async function initTelemetry(): Promise<void> {

--- a/upsun-mcp/src/core/telemetry.ts
+++ b/upsun-mcp/src/core/telemetry.ts
@@ -147,6 +147,16 @@ export async function initTelemetry(): Promise<void> {
     log.info('OpenTelemetry initialized successfully ✓');
   } catch (error) {
     log.error('Failed to initialize OpenTelemetry:', error);
+
+    // Clean up any partially-initialized SDK to prevent resource leaks.
+    try {
+      await sdk?.shutdown();
+    } catch (shutdownError) {
+      log.warn('Failed to clean up partially initialized OpenTelemetry SDK:', shutdownError);
+    } finally {
+      sdk = null;
+      isInitialized = false;
+    }
   }
 }
 

--- a/upsun-mcp/src/core/telemetry.ts
+++ b/upsun-mcp/src/core/telemetry.ts
@@ -49,11 +49,6 @@ function getSpanExporter(): ConsoleSpanExporter | OTLPTraceExporter {
       });
     }
 
-    case 'none':
-      log.info('Using no span exporter (traces collected but not exported)');
-      // Return a no-op exporter that does nothing
-      return new ConsoleSpanExporter(); // Will be filtered by sampler
-
     default:
       log.warn(`Unknown exporter type: ${otelConfig.exporterType}, defaulting to console`);
       return new ConsoleSpanExporter();
@@ -77,6 +72,11 @@ function getSpanExporter(): ConsoleSpanExporter | OTLPTraceExporter {
 export async function initTelemetry(): Promise<void> {
   if (!otelConfig.enabled) {
     log.info('OpenTelemetry is disabled via configuration');
+    return;
+  }
+
+  if (otelConfig.exporterType === 'none') {
+    log.info('OpenTelemetry exporter set to none, tracing is disabled');
     return;
   }
 
@@ -147,7 +147,6 @@ export async function initTelemetry(): Promise<void> {
     log.info('OpenTelemetry initialized successfully ✓');
   } catch (error) {
     log.error('Failed to initialize OpenTelemetry:', error);
-    throw error;
   }
 }
 

--- a/upsun-mcp/src/index.ts
+++ b/upsun-mcp/src/index.ts
@@ -8,11 +8,8 @@ import { McpType } from './core/types.js';
 const log = createLogger('main');
 
 // Initialize OpenTelemetry before starting the server.
-try {
-  await initTelemetry();
-} catch (err) {
-  log.error('Failed to initialize OpenTelemetry, continuing without tracing:', err);
-}
+// initTelemetry() handles errors internally and never throws.
+await initTelemetry();
 
 // Log configuration on startup
 log.info('Starting Upsun MCP Server...');

--- a/upsun-mcp/src/index.ts
+++ b/upsun-mcp/src/index.ts
@@ -7,8 +7,12 @@ import { McpType } from './core/types.js';
 
 const log = createLogger('main');
 
-// Initialize OpenTelemetry before starting the server
-await initTelemetry();
+// Initialize OpenTelemetry before starting the server.
+try {
+  await initTelemetry();
+} catch (err) {
+  log.error('Failed to initialize OpenTelemetry, continuing without tracing:', err);
+}
 
 // Log configuration on startup
 log.info('Starting Upsun MCP Server...');

--- a/upsun-mcp/test/core/telemetry-init-failure.test.ts
+++ b/upsun-mcp/test/core/telemetry-init-failure.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for OpenTelemetry initialization failure handling.
+ *
+ * Isolated in its own file because jest.unstable_mockModule for
+ * @opentelemetry/sdk-node contaminates the module registry for the
+ * rest of the test suite.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+describe('initTelemetry failure handling', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  it('should not throw when SDK.start() fails, and should leave telemetry disabled', async () => {
+    process.env.OTEL_ENABLED = 'true';
+    process.env.OTEL_EXPORTER_TYPE = 'console';
+
+    // Intercept NodeSDK so we can make start() throw.
+    jest.unstable_mockModule('@opentelemetry/sdk-node', () => ({
+      NodeSDK: class {
+        start() {
+          throw new Error('simulated SDK failure');
+        }
+        shutdown() {
+          return Promise.resolve();
+        }
+      },
+    }));
+
+    const { initTelemetry, isTelemetryEnabled, shutdownTelemetry } =
+      await import('../../src/core/telemetry.js');
+
+    // Must not throw.
+    await expect(initTelemetry()).resolves.not.toThrow();
+
+    // Telemetry should remain disabled.
+    expect(isTelemetryEnabled()).toBe(false);
+
+    // Shutdown should be safe to call afterwards.
+    await expect(shutdownTelemetry()).resolves.not.toThrow();
+  });
+});

--- a/upsun-mcp/test/core/telemetry-init.test.ts
+++ b/upsun-mcp/test/core/telemetry-init.test.ts
@@ -40,14 +40,14 @@ describe('Telemetry Initialization Paths', () => {
       await shutdownTelemetry();
     });
 
-    it('should initialize with none exporter', async () => {
+    it('should return early with none exporter (treated as disabled)', async () => {
       process.env.OTEL_ENABLED = 'true';
       process.env.OTEL_EXPORTER_TYPE = 'none';
 
-      const { initTelemetry, shutdownTelemetry } = await import('../../src/core/telemetry.js');
+      const { initTelemetry, isTelemetryEnabled } = await import('../../src/core/telemetry.js');
 
       await expect(initTelemetry()).resolves.not.toThrow();
-      await shutdownTelemetry();
+      expect(isTelemetryEnabled()).toBe(false);
     });
 
     it('should handle unknown exporter type', async () => {

--- a/upsun-mcp/test/core/telemetry.test.ts
+++ b/upsun-mcp/test/core/telemetry.test.ts
@@ -245,10 +245,12 @@ describe('Telemetry Module', () => {
       process.env.OTEL_ENABLED = 'true';
       process.env.OTEL_EXPORTER_TYPE = 'none';
 
-      const { initTelemetry, shutdownTelemetry } = await import('../../src/core/telemetry.js');
+      const { initTelemetry } = await import('../../src/core/telemetry.js');
 
+      // The none exporter case returns early without initializing.
+      // This test shares module state so it may already be initialized;
+      // the isolated test in telemetry-init.test.ts verifies the early return.
       await expect(initTelemetry()).resolves.not.toThrow();
-      await shutdownTelemetry();
     });
 
     it('should handle initTelemetry with otlp exporter', async () => {

--- a/upsun-mcp/test/core/telemetry.test.ts
+++ b/upsun-mcp/test/core/telemetry.test.ts
@@ -241,17 +241,8 @@ describe('Telemetry Module', () => {
       await shutdownTelemetry();
     });
 
-    it('should handle initTelemetry with none exporter', async () => {
-      process.env.OTEL_ENABLED = 'true';
-      process.env.OTEL_EXPORTER_TYPE = 'none';
-
-      const { initTelemetry } = await import('../../src/core/telemetry.js');
-
-      // The none exporter case returns early without initializing.
-      // This test shares module state so it may already be initialized;
-      // the isolated test in telemetry-init.test.ts verifies the early return.
-      await expect(initTelemetry()).resolves.not.toThrow();
-    });
+    // The none exporter path is tested with proper module isolation
+    // in telemetry-init.test.ts ('should return early with none exporter').
 
     it('should handle initTelemetry with otlp exporter', async () => {
       process.env.OTEL_ENABLED = 'true';


### PR DESCRIPTION
## Summary

- Default `OTEL_ENABLED` to `false` (was `true`, causing verbose console span output with no env var set)
- Make `initTelemetry()` non-fatal so the server starts without tracing if OTel initialization fails
- Treat exporter type `none` as disabled rather than falling through to `ConsoleSpanExporter`

Closes [AI-163: Ensure OTel code is safe to deploy](https://linear.app/platformsh/issue/AI-163/mcp-ensure-otel-code-is-safe-to-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)