### PR TITLE
fix: remove dotenv override that clobbers platform env vars

### DIFF
--- a/upsun-mcp/.environment
+++ b/upsun-mcp/.environment
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-OAUTH_BASE_URL=$(echo "$PLATFORM_ROUTES" | base64 -d | jq -r 'to_entries[] | select(.value.id == "mcp") | .value.production_url')
+OAUTH_BASE_URL=$(echo "$PLATFORM_ROUTES" | base64 -d | jq -r 'to_entries[] | select(.value.id == "mcp") | .key')
 export OAUTH_BASE_URL

--- a/upsun-mcp/src/core/config.ts
+++ b/upsun-mcp/src/core/config.ts
@@ -29,6 +29,8 @@ if (process.env.SKIP_DOTENV_LOAD !== 'true') {
   // Load environment-specific .env file first so it takes precedence over the
   // base .env. Neither call uses override, so pre-existing OS/platform
   // variables always win. Precedence: OS env > .env.<env> > .env
+  // NODE_ENV must be set via OS/platform env to select a non-default file;
+  // a value inside .env cannot influence which .env.<env> is loaded.
   const typeEnv = getNodeEnvironment();
   if (typeEnv) {
     const envPath = join(projectRoot, `.env.${typeEnv}`);

--- a/upsun-mcp/src/core/config.ts
+++ b/upsun-mcp/src/core/config.ts
@@ -36,7 +36,7 @@ if (process.env.SKIP_DOTENV_LOAD !== 'true') {
   if (typeEnv) {
     const envPath = join(projectRoot, `.env.${typeEnv}`);
     if (existsSync(envPath)) {
-      const specificEnv = dotenv.config({ path: envPath, override: true });
+      const specificEnv = dotenv.config({ path: envPath });
       dotenvExpand.expand(specificEnv);
     }
   }

--- a/upsun-mcp/src/core/config.ts
+++ b/upsun-mcp/src/core/config.ts
@@ -14,7 +14,7 @@ import dotenv from 'dotenv';
 import dotenvExpand from 'dotenv-expand';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { WritableMode, LogLevel, McpType } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -26,23 +26,46 @@ const projectRoot = join(__dirname, '..', '..');
 // Skip loading .env files during tests to allow tests to control environment.
 // Tests will set SKIP_DOTENV_LOAD=true to prevent .env loading.
 if (process.env.SKIP_DOTENV_LOAD !== 'true') {
-  // Load environment-specific .env file first so it takes precedence over the
-  // base .env. Neither call uses override, so pre-existing OS/platform
-  // variables always win. Precedence: OS env > .env.<env> > .env
+  // Merge dotenv files first, then expand once to support references across
+  // files. This allows .env.<env> to reference shared variables from .env.
+  // Precedence remains: OS env > .env.<env> > .env.
   // NODE_ENV must be set via OS/platform env to select a non-default file;
   // a value inside .env cannot influence which .env.<env> is loaded.
   const typeEnv = getNodeEnvironment();
-  if (typeEnv) {
-    const envPath = join(projectRoot, `.env.${typeEnv}`);
-    if (existsSync(envPath)) {
-      const specificEnv = dotenv.config({ path: envPath });
-      dotenvExpand.expand(specificEnv);
-    }
+  const baseEnvPath = join(projectRoot, '.env');
+  const specificEnvPath = typeEnv ? join(projectRoot, `.env.${typeEnv}`) : undefined;
+
+  const mergedDotenv: Record<string, string> = {};
+
+  if (existsSync(baseEnvPath)) {
+    Object.assign(mergedDotenv, dotenv.parse(readFileSync(baseEnvPath)));
   }
 
-  // Load base .env file (only sets keys not already present).
-  const baseEnv = dotenv.config({ path: join(projectRoot, '.env') });
-  dotenvExpand.expand(baseEnv);
+  if (specificEnvPath && existsSync(specificEnvPath)) {
+    Object.assign(mergedDotenv, dotenv.parse(readFileSync(specificEnvPath)));
+  }
+
+  if (Object.keys(mergedDotenv).length > 0) {
+    const processEnvForExpansion: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) {
+        processEnvForExpansion[key] = value;
+      }
+    }
+
+    const expanded = dotenvExpand.expand({
+      parsed: mergedDotenv,
+      // Use a copy to avoid dotenv-expand mutating process.env directly.
+      processEnv: processEnvForExpansion,
+    });
+
+    const resolvedDotenv = expanded.parsed ?? mergedDotenv;
+    for (const [key, value] of Object.entries(resolvedDotenv)) {
+      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = value;
+      }
+    }
+  }
 }
 
 /**

--- a/upsun-mcp/src/core/config.ts
+++ b/upsun-mcp/src/core/config.ts
@@ -23,15 +23,12 @@ const __dirname = dirname(__filename);
 // Project root is two levels up from this file (src/core/config.ts -> upsun-mcp/)
 const projectRoot = join(__dirname, '..', '..');
 
-// Skip loading .env files during tests to allow tests to control environment
-// Tests will set SKIP_DOTENV_LOAD=true to prevent .env loading
+// Skip loading .env files during tests to allow tests to control environment.
+// Tests will set SKIP_DOTENV_LOAD=true to prevent .env loading.
 if (process.env.SKIP_DOTENV_LOAD !== 'true') {
-  // Load base .env file first
-  const baseEnv = dotenv.config({ path: join(projectRoot, '.env') });
-  dotenvExpand.expand(baseEnv);
-
-  // Then try to load environment-specific .env file based on TYPE_ENV
-  // Use override: true to allow the specific env file to override base values
+  // Load environment-specific .env file first so it takes precedence over the
+  // base .env. Neither call uses override, so pre-existing OS/platform
+  // variables always win. Precedence: OS env > .env.<env> > .env
   const typeEnv = getNodeEnvironment();
   if (typeEnv) {
     const envPath = join(projectRoot, `.env.${typeEnv}`);
@@ -40,6 +37,10 @@ if (process.env.SKIP_DOTENV_LOAD !== 'true') {
       dotenvExpand.expand(specificEnv);
     }
   }
+
+  // Load base .env file (only sets keys not already present).
+  const baseEnv = dotenv.config({ path: join(projectRoot, '.env') });
+  dotenvExpand.expand(baseEnv);
 }
 
 /**

--- a/upsun-mcp/test/core/config-parsing.test.ts
+++ b/upsun-mcp/test/core/config-parsing.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { writeFileSync, rmSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { setupTestEnvironment, teardownTestEnvironment } from '../helpers/test-env.js';
@@ -283,12 +283,28 @@ describe('Configuration Parsing', () => {
   describe('dotenv loading precedence', () => {
     const envSuffix = `test-${process.pid}`;
     const envFile = join(projectRoot, `.env.${envSuffix}`);
+    const baseEnvFile = join(projectRoot, '.env');
+    let originalBaseEnvContents: string | null = null;
+
+    beforeEach(() => {
+      originalBaseEnvContents = existsSync(baseEnvFile) ? readFileSync(baseEnvFile, 'utf-8') : null;
+    });
 
     afterEach(() => {
       try {
         rmSync(envFile);
       } catch {
         // File may not exist.
+      }
+
+      if (originalBaseEnvContents === null) {
+        try {
+          rmSync(baseEnvFile);
+        } catch {
+          // File may not exist.
+        }
+      } else {
+        writeFileSync(baseEnvFile, originalBaseEnvContents);
       }
     });
 
@@ -318,8 +334,26 @@ describe('Configuration Parsing', () => {
       delete process.env.OTEL_SERVICE_NAME;
 
       const { otelConfig } = await import('../../src/core/config.js');
-      // .env.<env> is loaded first, so its value wins over .env base.
+      // .env.<env> overrides .env base for the same key.
       expect(otelConfig.serviceName).toBe('from-env-specific');
+    });
+
+    it('should allow .env.<env> to reference shared values from .env', async () => {
+      // Shared base variables.
+      writeFileSync(baseEnvFile, 'PORT=4321\n');
+      // Environment-specific variable referencing the shared base variable.
+      writeFileSync(envFile, 'OAUTH_BASE_URL=http://127.0.0.1:${PORT}/\n');
+
+      // Enable dotenv loading.
+      delete process.env.SKIP_DOTENV_LOAD;
+      process.env.NODE_ENV = envSuffix;
+      // Ensure values come from dotenv files rather than OS environment.
+      delete process.env.PORT;
+      delete process.env.OAUTH_BASE_URL;
+
+      const { oauth2Config, appConfig } = await import('../../src/core/config.js');
+      expect(appConfig.port).toBe(4321);
+      expect(oauth2Config.resourceUrl).toBe('http://127.0.0.1:4321/');
     });
   });
 });

--- a/upsun-mcp/test/core/config-parsing.test.ts
+++ b/upsun-mcp/test/core/config-parsing.test.ts
@@ -5,8 +5,17 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 import { setupTestEnvironment, teardownTestEnvironment } from '../helpers/test-env.js';
 import { WritableMode, McpType } from '../../src/core/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// config.ts resolves projectRoot as two levels up from src/core/config.ts
+const projectRoot = join(__dirname, '..', '..');
 
 describe('Configuration Parsing', () => {
   const originalEnv = process.env;
@@ -269,6 +278,48 @@ describe('Configuration Parsing', () => {
       const summary = getConfigSummary();
 
       expect(summary).toContain('2 headers');
+    });
+  });
+
+  describe('dotenv loading precedence', () => {
+    const envFile = join(projectRoot, '.env.test-dotenv');
+
+    afterEach(() => {
+      try {
+        rmSync(envFile);
+      } catch {
+        // File may not exist.
+      }
+    });
+
+    it('should not override pre-existing OS environment variables', async () => {
+      // Simulate a platform-provided env var that must not be clobbered.
+      process.env.OAUTH_BASE_URL = 'https://platform-provided.example.com/';
+
+      // Write a .env file that tries to set the same key.
+      writeFileSync(envFile, 'OAUTH_BASE_URL=http://127.0.0.1:3000/\n');
+
+      // Enable dotenv loading and point NODE_ENV at the temp file.
+      delete process.env.SKIP_DOTENV_LOAD;
+      process.env.NODE_ENV = 'test-dotenv';
+
+      const { oauth2Config } = await import('../../src/core/config.js');
+      expect(oauth2Config.resourceUrl).toBe('https://platform-provided.example.com/');
+    });
+
+    it('should use .env.<env> value over .env base value for same key', async () => {
+      // Write env-specific file with a distinct value.
+      writeFileSync(envFile, 'OTEL_SERVICE_NAME=from-env-specific\n');
+
+      // Enable dotenv loading.
+      delete process.env.SKIP_DOTENV_LOAD;
+      process.env.NODE_ENV = 'test-dotenv';
+      // Ensure the key is not already in OS env so dotenv files compete.
+      delete process.env.OTEL_SERVICE_NAME;
+
+      const { otelConfig } = await import('../../src/core/config.js');
+      // .env.test-dotenv is loaded first, so its value wins over .env base.
+      expect(otelConfig.serviceName).toBe('from-env-specific');
     });
   });
 });

--- a/upsun-mcp/test/core/config-parsing.test.ts
+++ b/upsun-mcp/test/core/config-parsing.test.ts
@@ -281,7 +281,8 @@ describe('Configuration Parsing', () => {
   });
 
   describe('dotenv loading precedence', () => {
-    const envFile = join(projectRoot, '.env.test-dotenv');
+    const envSuffix = `test-${process.pid}`;
+    const envFile = join(projectRoot, `.env.${envSuffix}`);
 
     afterEach(() => {
       try {
@@ -300,7 +301,7 @@ describe('Configuration Parsing', () => {
 
       // Enable dotenv loading and point NODE_ENV at the temp file.
       delete process.env.SKIP_DOTENV_LOAD;
-      process.env.NODE_ENV = 'test-dotenv';
+      process.env.NODE_ENV = envSuffix;
 
       const { oauth2Config } = await import('../../src/core/config.js');
       expect(oauth2Config.resourceUrl).toBe('https://platform-provided.example.com/');
@@ -312,12 +313,12 @@ describe('Configuration Parsing', () => {
 
       // Enable dotenv loading.
       delete process.env.SKIP_DOTENV_LOAD;
-      process.env.NODE_ENV = 'test-dotenv';
+      process.env.NODE_ENV = envSuffix;
       // Ensure the key is not already in OS env so dotenv files compete.
       delete process.env.OTEL_SERVICE_NAME;
 
       const { otelConfig } = await import('../../src/core/config.js');
-      // .env.test-dotenv is loaded first, so its value wins over .env base.
+      // .env.<env> is loaded first, so its value wins over .env base.
       expect(otelConfig.serviceName).toBe('from-env-specific');
     });
   });

--- a/upsun-mcp/test/core/config-parsing.test.ts
+++ b/upsun-mcp/test/core/config-parsing.test.ts
@@ -5,10 +5,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { writeFileSync, mkdirSync, rmSync } from 'fs';
-import { join } from 'path';
+import { writeFileSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { dirname } from 'path';
 import { setupTestEnvironment, teardownTestEnvironment } from '../helpers/test-env.js';
 import { WritableMode, McpType } from '../../src/core/types.js';
 


### PR DESCRIPTION
## Summary

- `.env.development` was loaded with `override: true`, causing it to overwrite environment variables set by the Upsun platform (via `.environment` and `upsun variable:create`)
- This caused the OAuth2 resource URL to advertise `http://127.0.0.1:3000/mcp` instead of the actual public URL on both production and staging
- Removes `override: true` and swaps the dotenv load order so `.env.<env>` can override `.env` base values while OS/platform variables always take precedence
- Fixes `.environment` to derive `OAUTH_BASE_URL` from the route key (the actual URL) instead of `production_url`, which is empty on non-production environments
- Adds regression tests for dotenv loading precedence

Closes [AI-177: Fix dotenv override clobbering platform environment variables](https://linear.app/platformsh/issue/AI-177/fix-dotenv-override-clobbering-platform-environment-variables)

Generated with [Claude Code](https://claude.com/claude-code)