### PR TITLE
remove unimplemented mcp tools

### DIFF
--- a/upsun-mcp/src/command/route.ts
+++ b/upsun-mcp/src/command/route.ts
@@ -91,5 +91,4 @@ export function registerRoute(adapter: McpAdapter): void {
       return Response.json(result);
     })
   );
-
 }

--- a/upsun-mcp/src/command/route.ts
+++ b/upsun-mcp/src/command/route.ts
@@ -17,10 +17,9 @@ const log = createLogger('MCP:Tool:route-commands');
 /**
  * Registers route management tools with the MCP server.
  *
- * This function adds three tools for route operations:
+ * This function adds two tools for route operations:
  * - get-route: Retrieves information about a specific route
  * - list-route: Lists all routes for an environment
- * - get-console: Gets the web console URL for a project
  *
  * @param adapter - The MCP adapter instance to register tools with
  *
@@ -93,31 +92,4 @@ export function registerRoute(adapter: McpAdapter): void {
     })
   );
 
-  /**
-   * Tool: get-console
-   * Retrieves the web console URL for a specific project.
-   *
-   * The web console URL provides access to the Upsun management interface
-   * for the project, where users can view and manage environments, deployments,
-   * and other project settings.
-   *
-   * @param project_id - The project ID to get the console URL for
-   */
-  adapter.server.registerTool(
-    'get-console',
-    {
-      annotations: { readOnlyHint: true },
-      description: 'Get console URL of upsun project',
-      inputSchema: {
-        project_id: Schema.projectId(),
-      },
-    },
-    ToolWrapper.trace('get-console', async ({ project_id }) => {
-      log.debug(`Get Console URL of Project: ${project_id}`);
-      //const result = (await adapter.client.routes.web(project_id)).ui;
-      const result = 'Not implemented';
-
-      return Response.json(result);
-    })
-  );
 }

--- a/upsun-mcp/src/command/route.ts
+++ b/upsun-mcp/src/command/route.ts
@@ -2,8 +2,8 @@
  * @fileoverview Route management command module for Upsun MCP server.
  *
  * This module provides MCP tools for managing Upsun routes, which define how
- * HTTP requests are handled within a project environment. It also includes
- * utilities for retrieving URLs and console access links.
+ * HTTP requests are handled within a project environment. It includes
+ * utilities for retrieving route information and URLs.
  */
 
 import { McpAdapter } from '../core/adapter.js';

--- a/upsun-mcp/src/command/ssh.ts
+++ b/upsun-mcp/src/command/ssh.ts
@@ -101,5 +101,4 @@ export function registerSshKey(adapter: McpAdapter): void {
       })
     );
   }
-
 }

--- a/upsun-mcp/src/command/ssh.ts
+++ b/upsun-mcp/src/command/ssh.ts
@@ -18,10 +18,10 @@ const log = createLogger('MCP:Tool:ssh-commands');
 /**
  * Registers SSH key management tools with the MCP server.
  *
- * This function adds three tools for SSH key operations:
+ * This function adds two tools for SSH key operations:
  * - add-sshkey: Adds a new SSH key to a user account
  * - delete-sshkey: Removes an existing SSH key from a user account
- * - list-sshkey: Lists all SSH keys for a user account
+ *
  *
  * @param adapter - The MCP adapter instance to register tools with
  *
@@ -102,29 +102,4 @@ export function registerSshKey(adapter: McpAdapter): void {
     );
   }
 
-  /**
-   * Tool: list-sshkey
-   * Lists all SSH keys for a specific user account.
-   *
-   * Returns an array of SSH keys with information such as key ID,
-   * fingerprint, type, and creation date.
-   *
-   * @param user_id - The ID of the user to list SSH keys for
-   */
-  adapter.server.registerTool(
-    'list-sshkey',
-    {
-      annotations: { readOnlyHint: true },
-      description: 'List all SSH keys of upsun account',
-      inputSchema: {
-        user_id: z.string(),
-      },
-    },
-    ToolWrapper.trace('list-sshkey', async ({ user_id }) => {
-      log.debug(`List SSH Keys for User: ${user_id}`);
-      const result = 'Not implemented in upsun-sdk-node@0.4.1 (no list SSH keys endpoint)';
-
-      return Response.json(result);
-    })
-  );
 }

--- a/upsun-mcp/test/command/route.test.ts
+++ b/upsun-mcp/test/command/route.test.ts
@@ -18,7 +18,6 @@ jest.mock('../../src/core/logger', () => ({
 const mockRoutesApi = {
   get: jest.fn(),
   list: jest.fn(),
-  web: jest.fn(),
 };
 
 // Mock the adapter
@@ -67,12 +66,11 @@ describe('Route Command Module', () => {
   describe('registerRoute function', () => {
     it('should register all route tools', () => {
       // Don't call registerRoute again since it's already called in beforeEach
-      expect(mockAdapter.server.registerTool).toHaveBeenCalledTimes(3) as any;
+      expect(mockAdapter.server.registerTool).toHaveBeenCalledTimes(2) as any;
 
       // Verify all tools are registered
       expect(toolCallbacks['get-route']).toBeDefined() as any;
       expect(toolCallbacks['list-route']).toBeDefined() as any;
-      expect(toolCallbacks['get-console']).toBeDefined() as any;
     });
 
     it('should register tools with correct names and descriptions', () => {
@@ -99,15 +97,6 @@ describe('Route Command Module', () => {
         expect.any(Function),
       ]) as any;
 
-      expect(calls[2]).toEqual([
-        'get-console',
-        {
-          annotations: { readOnlyHint: true },
-          description: 'Get console URL of upsun project',
-          inputSchema: expect.any(Object),
-        },
-        expect.any(Function),
-      ]) as any;
     });
   });
 
@@ -350,87 +339,6 @@ describe('Route Command Module', () => {
     }) as any;
   }) as any;
 
-  describe('get-console tool', () => {
-    it('should get console URL for project', async () => {
-      const mockWebData = {
-        ui: 'https://console.upsun.com/projects/test-project-13',
-      };
-
-      // @ts-ignore
-      mockAdapter.client.routes.web = jest.fn().mockResolvedValue(mockWebData) as any;
-
-      const callback = toolCallbacks['get-console'];
-      const params = {
-        project_id: 'test-project-13',
-      };
-
-      const result = (await callback(params)) as any;
-
-      // Since the function returns "Not implemented", we don't expect any client calls
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify('Not implemented', null, 2),
-          },
-        ],
-      }) as any;
-    }) as any;
-
-    it('should handle different project console URLs', async () => {
-      const mockWebData = {
-        ui: 'https://console.upsun.com/projects/enterprise-project-456',
-      };
-
-      // @ts-ignore
-      mockAdapter.client.routes.web = jest.fn().mockResolvedValue(mockWebData) as any;
-
-      const callback = toolCallbacks['get-console'];
-      const params = {
-        project_id: 'enterprise-project-456',
-      };
-
-      const result = (await callback(params)) as any;
-
-      // Since the function returns "Not implemented", we don't expect any client calls
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify('Not implemented', null, 2),
-          },
-        ],
-      }) as any;
-    }) as any;
-
-    it('should handle console URL with additional metadata', async () => {
-      const mockWebData = {
-        ui: 'https://console.upsun.com/projects/complex-project',
-        api: 'https://api.upsun.com/projects/complex-project',
-        ssh: 'ssh://complex-project@ssh.upsun.com',
-      };
-
-      // @ts-ignore
-      mockAdapter.client.routes.web = jest.fn().mockResolvedValue(mockWebData) as any;
-
-      const callback = toolCallbacks['get-console'];
-      const params = {
-        project_id: 'complex-project',
-      };
-
-      const result = (await callback(params)) as any;
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify('Not implemented', null, 2),
-          },
-        ],
-      }) as any;
-    }) as any;
-  }) as any;
-
   describe('error handling and edge cases', () => {
     it('should handle API errors for get-route', async () => {
       const error = new Error('Route not found') as any;
@@ -459,25 +367,6 @@ describe('Route Command Module', () => {
       };
 
       (await expect(callback(params)).rejects.toThrow('Environment not found')) as any;
-    }) as any;
-
-    it('should handle API errors for get-console', async () => {
-      // Since get-console always returns "Not implemented" and doesn't call the client,
-      // it cannot throw errors. This test verifies the current behavior.
-      const callback = toolCallbacks['get-console'];
-      const params = {
-        project_id: 'restricted-project',
-      };
-
-      const result = (await callback(params)) as any;
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify('Not implemented', null, 2),
-          },
-        ],
-      }) as any;
     }) as any;
 
     it('should handle null/undefined responses', async () => {

--- a/upsun-mcp/test/command/route.test.ts
+++ b/upsun-mcp/test/command/route.test.ts
@@ -96,7 +96,6 @@ describe('Route Command Module', () => {
         },
         expect.any(Function),
       ]) as any;
-
     });
   });
 

--- a/upsun-mcp/test/command/ssh.test.ts
+++ b/upsun-mcp/test/command/ssh.test.ts
@@ -15,8 +15,6 @@ jest.mock('../../src/core/logger', () => ({
   createLogger: jest.fn(() => mockLogger),
 }));
 
-const listSshKeysMessage = 'Not implemented in upsun-sdk-node@0.4.1 (no list SSH keys endpoint)';
-
 // Mock the Upsun client (add methods here if needed)
 const mockClient: any = {};
 
@@ -61,15 +59,10 @@ describe('SSH Key Command Module', () => {
       add: jest.fn() as jest.Mock,
       delete: jest.fn() as jest.Mock,
       get: jest.fn() as jest.Mock,
-      list: jest.fn() as jest.Mock,
     };
     (sshMock.add as any).mockResolvedValue('sshkey-added');
     (sshMock.delete as any).mockResolvedValue('sshkey-deleted');
     (sshMock.get as any).mockResolvedValue({ id: 'sshkey-1', type: 'rsa' });
-    (sshMock.list as any).mockResolvedValue([
-      { id: 'sshkey-1', type: 'rsa' },
-      { id: 'sshkey-2', type: 'ed25519' },
-    ]);
     (mockAdapter as any).client.ssh = sshMock;
   });
 
@@ -82,12 +75,11 @@ describe('SSH Key Command Module', () => {
     it('should register all SSH key tools', () => {
       registerSshKey(mockAdapter);
 
-      expect(mockAdapter.server.registerTool).toHaveBeenCalledTimes(3);
+      expect(mockAdapter.server.registerTool).toHaveBeenCalledTimes(2);
 
       // Verify all tools are registered
       expect(toolCallbacks['add-sshkey']).toBeDefined();
       expect(toolCallbacks['delete-sshkey']).toBeDefined();
-      expect(toolCallbacks['list-sshkey']).toBeDefined();
     });
 
     it('should register tools with correct names and descriptions', () => {
@@ -115,15 +107,6 @@ describe('SSH Key Command Module', () => {
         expect.any(Function),
       ]);
 
-      expect(calls[2]).toEqual([
-        'list-sshkey',
-        {
-          annotations: { readOnlyHint: true },
-          description: 'List all SSH keys of upsun account',
-          inputSchema: expect.any(Object),
-        },
-        expect.any(Function),
-      ]);
     });
   });
 
@@ -280,88 +263,6 @@ describe('SSH Key Command Module', () => {
     });
   });
 
-  describe('list-sshkey tool', () => {
-    beforeEach(() => {
-      registerSshKey(mockAdapter);
-    });
-
-    it('should return TODO for list SSH keys', async () => {
-      const callback = toolCallbacks['list-sshkey'];
-      const params = {
-        user_id: 'user-123',
-      };
-
-      const result = await callback(params);
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(listSshKeysMessage, null, 2),
-          },
-        ],
-      });
-    });
-
-    it('should handle listing for different user types', async () => {
-      const callback = toolCallbacks['list-sshkey'];
-      const testCases = [
-        { user_id: 'admin-user' },
-        { user_id: 'regular-user-456' },
-        { user_id: 'service-account-789' },
-        { user_id: 'enterprise-user-abc' },
-      ];
-
-      for (const params of testCases) {
-        const result = await callback(params);
-        expect(result).toEqual({
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(listSshKeysMessage, null, 2),
-            },
-          ],
-        });
-      }
-    });
-
-    it('should handle corporate user accounts', async () => {
-      const callback = toolCallbacks['list-sshkey'];
-      const params = {
-        user_id: 'corporate-admin-123456',
-      };
-
-      const result = await callback(params);
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(listSshKeysMessage, null, 2),
-          },
-        ],
-      });
-    });
-
-    it('should handle API service accounts', async () => {
-      const callback = toolCallbacks['list-sshkey'];
-      const params = {
-        user_id: 'api-service-deployment-bot',
-      };
-
-      const result = await callback(params);
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(listSshKeysMessage, null, 2),
-          },
-        ],
-      });
-    });
-  });
-
   describe('parameter validation and edge cases', () => {
     beforeEach(() => {
       registerSshKey(mockAdapter);
@@ -384,12 +285,6 @@ describe('SSH Key Command Module', () => {
             key_id: 'k',
           },
         },
-        {
-          name: 'list-sshkey',
-          params: {
-            user_id: 'u',
-          },
-        },
       ];
 
       for (const { name, params } of callbacks) {
@@ -400,8 +295,6 @@ describe('SSH Key Command Module', () => {
           expected = 'sshkey-added';
         } else if (name === 'delete-sshkey') {
           expected = 'sshkey-deleted';
-        } else if (name === 'list-sshkey') {
-          expected = listSshKeysMessage;
         }
         expect(result).toEqual({
           content: [{ type: 'text', text: JSON.stringify(expected, null, 2) }],
@@ -426,20 +319,16 @@ describe('SSH Key Command Module', () => {
     });
 
     it('should handle numeric user IDs', async () => {
-      const callback = toolCallbacks['list-sshkey'];
+      const callback = toolCallbacks['delete-sshkey'];
       const params = {
         user_id: '123456789',
+        key_id: '12345',
       };
 
       const result = await callback(params);
 
       expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(listSshKeysMessage, null, 2),
-          },
-        ],
+        content: [{ type: 'text', text: JSON.stringify('sshkey-deleted', null, 2) }],
       });
     });
 

--- a/upsun-mcp/test/command/ssh.test.ts
+++ b/upsun-mcp/test/command/ssh.test.ts
@@ -106,7 +106,6 @@ describe('SSH Key Command Module', () => {
         },
         expect.any(Function),
       ]);
-
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove `list-sshkey` tool that returned a hardcoded "not implemented" string since the upsun-sdk-node 0.4 upgrade
- Remove `get-console` tool (also a stub with the SDK call commented out), found during audit of all command modules
- Unimplemented tools waste context window tokens in LLM clients

Closes [AI-161: Remove unimplemented MCP tools](https://linear.app/platformsh/issue/AI-161/remove-unimplemented-mcp-tools-eg-list-sshkey)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes only stubbed tools that returned hardcoded "Not implemented" strings; behavior change is limited to tool availability and corresponding tests.
> 
> **Overview**
> Removes the unimplemented MCP tools `get-console` (routes) and `list-sshkey` (SSH), leaving only the functional route (`get-route`, `list-route`) and SSH key (`add-sshkey`, `delete-sshkey`) commands.
> 
> Updates unit tests and tool registration expectations to reflect the reduced tool surface, and drops the stub-specific mocks and assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82ffa8d7fe71a23e86021bf30a42a373ae73b211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->