### PR TITLE
fix(auth): ignore placeholder and empty api-token headers

### DIFF
--- a/upsun-mcp/src/core/authentication.ts
+++ b/upsun-mcp/src/core/authentication.ts
@@ -166,9 +166,21 @@ export class JwtTokenVerifier {
 }
 
 /**
+ * Detects unsubstituted shell-style placeholders (e.g. `${UPSUN_API_TOKEN}`)
+ * that can reach the server when a client forwards a templated config header
+ * verbatim because the referenced environment variable is unset.
+ */
+function isUnsubstitutedPlaceholder(value: string): boolean {
+  return /^\$\{[^}]*\}$/.test(value);
+}
+
+/**
  * Combined authentication middleware that supports both bearer tokens (via the
  * SDK's requireBearerAuth) and legacy API keys. API key requests bypass bearer
  * validation entirely.
+ *
+ * An API key header whose value is empty or an unsubstituted placeholder is
+ * ignored so the bearer flow can still run.
  */
 export function requireMcpAuth(
   verifier: JwtTokenVerifier,
@@ -178,10 +190,15 @@ export function requireMcpAuth(
 
   return (req, res, next) => {
     const raw = req.headers[HeaderKey.API_KEY];
-    const apiKey = typeof raw === 'string' ? raw : undefined;
-    if (apiKey) {
+    const apiKey = typeof raw === 'string' ? raw.trim() : undefined;
+    if (apiKey && !isUnsubstitutedPlaceholder(apiKey)) {
       req.auth = { token: apiKey, clientId: API_KEY_CLIENT_ID, scopes: [] };
       return next();
+    }
+    if (apiKey && isUnsubstitutedPlaceholder(apiKey)) {
+      log.warn(
+        `Ignoring ${HeaderKey.API_KEY} header with unsubstituted placeholder value; falling back to bearer auth`
+      );
     }
     bearerAuth(req, res, next);
   };

--- a/upsun-mcp/src/core/authentication.ts
+++ b/upsun-mcp/src/core/authentication.ts
@@ -179,8 +179,8 @@ function isUnsubstitutedPlaceholder(value: string): boolean {
  * SDK's requireBearerAuth) and legacy API keys. API key requests bypass bearer
  * validation entirely.
  *
- * An API key header whose value is empty or an unsubstituted placeholder is
- * ignored so the bearer flow can still run.
+ * An API key header whose value is an unsubstituted placeholder is ignored so
+ * the bearer flow can still run.
  */
 export function requireMcpAuth(
   verifier: JwtTokenVerifier,
@@ -190,7 +190,7 @@ export function requireMcpAuth(
 
   return (req, res, next) => {
     const raw = req.headers[HeaderKey.API_KEY];
-    const apiKey = typeof raw === 'string' ? raw.trim() : undefined;
+    const apiKey = typeof raw === 'string' ? raw : undefined;
     if (apiKey && !isUnsubstitutedPlaceholder(apiKey)) {
       req.auth = { token: apiKey, clientId: API_KEY_CLIENT_ID, scopes: [] };
       return next();

--- a/upsun-mcp/test/core/authentication.test.ts
+++ b/upsun-mcp/test/core/authentication.test.ts
@@ -258,6 +258,49 @@ describe('Authentication Module', () => {
       expect(mockNext).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
     });
+
+    it('should ignore an API key header with an unsubstituted placeholder value', () => {
+      const verifier = new JwtTokenVerifier();
+      const middleware = requireMcpAuth(verifier);
+
+      const req = {
+        headers: { 'upsun-api-token': '${UPSUN_API_TOKEN}' },
+      } as unknown as express.Request;
+      const res = {
+        status: jest.fn().mockReturnThis() as any,
+        json: jest.fn() as any,
+        set: jest.fn() as any,
+        setHeader: jest.fn() as any,
+      } as unknown as express.Response;
+
+      middleware(req, res, mockNext);
+
+      // Placeholder is ignored; bearer middleware runs and rejects unauthenticated requests.
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(req.auth).toBeUndefined();
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it('should ignore an empty API key header', () => {
+      const verifier = new JwtTokenVerifier();
+      const middleware = requireMcpAuth(verifier);
+
+      const req = {
+        headers: { 'upsun-api-token': '   ' },
+      } as unknown as express.Request;
+      const res = {
+        status: jest.fn().mockReturnThis() as any,
+        json: jest.fn() as any,
+        set: jest.fn() as any,
+        setHeader: jest.fn() as any,
+      } as unknown as express.Response;
+
+      middleware(req, res, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(req.auth).toBeUndefined();
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
   });
 
   describe('Path-suffixed well-known routes', () => {

--- a/upsun-mcp/test/core/authentication.test.ts
+++ b/upsun-mcp/test/core/authentication.test.ts
@@ -280,27 +280,6 @@ describe('Authentication Module', () => {
       expect(req.auth).toBeUndefined();
       expect(res.status).toHaveBeenCalledWith(401);
     });
-
-    it('should ignore an empty API key header', () => {
-      const verifier = new JwtTokenVerifier();
-      const middleware = requireMcpAuth(verifier);
-
-      const req = {
-        headers: { 'upsun-api-token': '   ' },
-      } as unknown as express.Request;
-      const res = {
-        status: jest.fn().mockReturnThis() as any,
-        json: jest.fn() as any,
-        set: jest.fn() as any,
-        setHeader: jest.fn() as any,
-      } as unknown as express.Response;
-
-      middleware(req, res, mockNext);
-
-      expect(mockNext).not.toHaveBeenCalled();
-      expect(req.auth).toBeUndefined();
-      expect(res.status).toHaveBeenCalledWith(401);
-    });
   });
 
   describe('Path-suffixed well-known routes', () => {


### PR DESCRIPTION
## Summary

`requireMcpAuth` treats any non-empty `upsun-api-token` header as an API key and short-circuits bearer/OAuth2 validation.

Claude Code's Upsun plugin templates the header as `"upsun-api-token": "${UPSUN_API_TOKEN}"`. When the env var is unset, Claude Code sends the literal string `${UPSUN_API_TOKEN}` — confirmed via mitmproxy. The server accepts that placeholder as an API key, initialises the Upsun SDK with it, and the SDK's `grant_type=api_token` exchange fails with an opaque `Token exchange failed` — even when the request also carries a valid OAuth2 bearer token that would have succeeded.

## Fix

- Ignore `upsun-api-token` header values matching `/^\$\{[^}]*\}$/`.
- Log a warning when this happens so operators can spot the client misconfiguration.
- Keep existing precedence otherwise: a legitimate API key still bypasses bearer validation.
- Add a test for the placeholder case.

## Related

- Plugin side: upsun/ai#17 (kept as draft — convenience of the env-var reference is worth preserving, so this server-side fix is the primary path).
- SDK follow-up (not in this PR): `upsun-sdk-node`'s `OAuth2Client.exchangeCodeForToken` throws a bare `Token exchange failed` without including the auth response status or body. Propagating that would make similar incidents diagnosable in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)