### PR TITLE
feat: add pagination params to list-project and list-organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You don't need to install or run anything locally unless you're developing or cu
 - **create-project**: Create new Upsun projects within organizations
 - **delete-project**: Permanently delete projects and all resources
 - **info-project**: Get detailed project information and metadata
-- **list-project**: List all projects in an organization
+- **list-project**: List projects in an organization. Supports cursor-based pagination via `page_size`, `page_after`, and `page_before` to retrieve more than the default page of results.
 
 ### 🌍 Environment Management
 - **activate-environment**: Activate paused environments
@@ -33,7 +33,7 @@ You don't need to install or run anything locally unless you're developing or cu
 
 ### 🏢 Organization Management
 - **info-organization**: Get organization details
-- **list-organization**: List all accessible organizations
+- **list-organization**: List accessible organizations. Supports cursor-based pagination via `page_size`, `page_after`, and `page_before`.
 
 ### 📊 Activity & Monitoring
 - **list-activity**: View deployment activities and logs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You don't need to install or run anything locally unless you're developing or cu
 - **create-project**: Create new Upsun projects within organizations
 - **delete-project**: Permanently delete projects and all resources
 - **info-project**: Get detailed project information and metadata
-- **list-project**: List projects in an organization. Supports cursor-based pagination via `page_size`, `page_after`, and `page_before` to retrieve more than the default page of results.
+- **list-project**: List projects in an organization. Supports pagination via `page_size` for the first page and `page_link` with `links.next.href` or `links.previous.href` to follow pages.
 
 ### 🌍 Environment Management
 - **activate-environment**: Activate paused environments
@@ -33,7 +33,7 @@ You don't need to install or run anything locally unless you're developing or cu
 
 ### 🏢 Organization Management
 - **info-organization**: Get organization details
-- **list-organization**: List accessible organizations. Supports cursor-based pagination via `page_size`, `page_after`, and `page_before`.
+- **list-organization**: List accessible organizations. Supports pagination via `page_size` for the first page and `page_link` with `links.next.href` or `links.previous.href` to follow pages.
 
 ### 📊 Activity & Monitoring
 - **list-activity**: View deployment activities and logs

--- a/upsun-mcp/src/command/organization.ts
+++ b/upsun-mcp/src/command/organization.ts
@@ -131,15 +131,15 @@ export function registerOrganization(adapter: McpAdapter): void {
     {
       annotations: { readOnlyHint: true },
       description:
-        'List all my organizations on upsun. Results are paginated; follow `links.next.href` via `page_after` to retrieve additional pages.',
+        'List all my organizations on upsun. Results are paginated; pass `links.next.href` or `links.previous.href` as `page_link` to follow pages.',
       inputSchema: {
         ...Schema.pagination(),
       },
     },
-    ToolWrapper.trace('list-organization', async ({ page_size, page_after, page_before }) => {
+    ToolWrapper.trace('list-organization', async ({ page_size, page_link }) => {
       log.debug(`List all my organizations`);
       const result = await adapter.client.organizations.listCurrentUserOrgs(
-        toSdkPagination({ page_size, page_after, page_before })
+        toSdkPagination({ page_size, page_link })
       );
 
       return Response.json(result);

--- a/upsun-mcp/src/command/organization.ts
+++ b/upsun-mcp/src/command/organization.ts
@@ -7,7 +7,7 @@
  */
 
 import { McpAdapter } from '../core/adapter.js';
-import { Response, Schema, ToolWrapper } from '../core/helper.js';
+import { Response, Schema, ToolWrapper, toSdkPagination } from '../core/helper.js';
 import { createLogger } from '../core/logger.js';
 
 // Create logger for organization operations
@@ -130,12 +130,17 @@ export function registerOrganization(adapter: McpAdapter): void {
     'list-organization',
     {
       annotations: { readOnlyHint: true },
-      description: 'List all my organizations on upsun',
-      inputSchema: {},
+      description:
+        'List all my organizations on upsun. Results are paginated; follow `links.next.href` via `page_after` to retrieve additional pages.',
+      inputSchema: {
+        ...Schema.pagination(),
+      },
     },
-    ToolWrapper.trace('list-organization', async () => {
+    ToolWrapper.trace('list-organization', async ({ page_size, page_after, page_before }) => {
       log.debug(`List all my organizations`);
-      const result = await adapter.client.organizations.listCurrentUserOrgs();
+      const result = await adapter.client.organizations.listCurrentUserOrgs(
+        toSdkPagination({ page_size, page_after, page_before })
+      );
 
       return Response.json(result);
     })

--- a/upsun-mcp/src/command/project.ts
+++ b/upsun-mcp/src/command/project.ts
@@ -12,7 +12,7 @@ import { createLogger } from '../core/logger.js';
 
 // Create logger for project operations
 const log = createLogger('MCP:Tool:project-commands');
-import { Response, Schema, ToolWrapper } from '../core/helper.js';
+import { Response, Schema, ToolWrapper, toSdkPagination } from '../core/helper.js';
 import { z } from 'zod';
 
 /**
@@ -152,16 +152,21 @@ export function registerProject(adapter: McpAdapter): void {
     'list-project',
     {
       annotations: { readOnlyHint: true },
-      description: 'List all upsun projects',
+      description:
+        'List upsun projects in an organization. Results are paginated; follow `links.next.href` via `page_after` to retrieve additional pages.',
       inputSchema: {
         organization_id: Schema.organizationId(),
+        ...Schema.pagination(),
       },
     },
     ToolWrapper.traceWithMetrics(
       'list-project',
-      async ({ organization_id }) => {
+      async ({ organization_id, page_size, page_after, page_before }) => {
         log.debug(`List all my projects in Organization: ${organization_id}`);
-        const result = await adapter.client.projects.list(organization_id);
+        const result = await adapter.client.projects.list(
+          organization_id,
+          toSdkPagination({ page_size, page_after, page_before })
+        );
 
         return Response.json(result);
       },

--- a/upsun-mcp/src/command/project.ts
+++ b/upsun-mcp/src/command/project.ts
@@ -153,7 +153,7 @@ export function registerProject(adapter: McpAdapter): void {
     {
       annotations: { readOnlyHint: true },
       description:
-        'List upsun projects in an organization. Results are paginated; follow `links.next.href` via `page_after` to retrieve additional pages.',
+        'List upsun projects in an organization. Results are paginated; pass `links.next.href` or `links.previous.href` as `page_link` to follow pages.',
       inputSchema: {
         organization_id: Schema.organizationId(),
         ...Schema.pagination(),
@@ -161,11 +161,11 @@ export function registerProject(adapter: McpAdapter): void {
     },
     ToolWrapper.traceWithMetrics(
       'list-project',
-      async ({ organization_id, page_size, page_after, page_before }) => {
+      async ({ organization_id, page_size, page_link }) => {
         log.debug(`List all my projects in Organization: ${organization_id}`);
         const result = await adapter.client.projects.list(
           organization_id,
-          toSdkPagination({ page_size, page_after, page_before })
+          toSdkPagination({ page_size, page_link })
         );
 
         return Response.json(result);

--- a/upsun-mcp/src/command/project.ts
+++ b/upsun-mcp/src/command/project.ts
@@ -7,13 +7,12 @@
  */
 
 import { SubscriptionStatusEnum } from 'upsun-sdk-node/dist/model/index.js';
+import { z } from 'zod';
 import { McpAdapter } from '../core/adapter.js';
+import { Response, Schema, ToolWrapper, toSdkPagination } from '../core/helper.js';
 import { createLogger } from '../core/logger.js';
 
-// Create logger for project operations
 const log = createLogger('MCP:Tool:project-commands');
-import { Response, Schema, ToolWrapper, toSdkPagination } from '../core/helper.js';
-import { z } from 'zod';
 
 /**
  * Registers project management tools with the MCP server.

--- a/upsun-mcp/src/core/helper.ts
+++ b/upsun-mcp/src/core/helper.ts
@@ -121,16 +121,14 @@ export class Schema {
 
   /**
    * Returns the Zod schema fields for pagination parameters supported by the
-   * Upsun API. To follow a next/previous page, take the cursor from
-   * `links.next.href` (or `links.previous.href`) in the previous response and
-   * pass it back as `page_after` or `page_before`.
+   * Upsun API. To follow a next/previous page, pass `links.next.href` or
+   * `links.previous.href` from the previous response as `page_link`.
    *
-   * @returns Zod input-schema fields for cursor-based pagination.
+   * @returns Zod input-schema fields for link-based pagination.
    */
   static pagination(): {
     page_size: z.ZodOptional<z.ZodNumber>;
-    page_after: z.ZodOptional<z.ZodString>;
-    page_before: z.ZodOptional<z.ZodString>;
+    page_link: z.ZodOptional<z.ZodString>;
   } {
     return {
       page_size: z
@@ -139,18 +137,14 @@ export class Schema {
         .min(1)
         .max(100)
         .optional()
-        .describe('Number of items per page (1-100). Defaults to the API default (typically 50).'),
-      page_after: z
-        .string()
-        .optional()
         .describe(
-          'Cursor for the next page. Use the value from `links.next.href` of the previous response.'
+          'Number of items for the first page (1-100). Defaults to the API default (typically 50).'
         ),
-      page_before: z
+      page_link: z
         .string()
         .optional()
         .describe(
-          'Cursor for the previous page. Use the value from `links.previous.href` of the previous response.'
+          'Opaque pagination link. Use `links.next.href` or `links.previous.href` from the previous response.'
         ),
     };
   }
@@ -161,42 +155,64 @@ export class Schema {
  */
 export interface PaginationParams {
   page_size?: number;
-  page_after?: string;
-  page_before?: string;
+  page_link?: string;
 }
 
 /**
  * Translates MCP-style snake_case pagination params into the camelCase filter
- * shape expected by the Upsun SDK. The `pageBefore` / `pageAfter` values may be
- * either a bare cursor or a URL (e.g. `links.next.href`); URLs are parsed so
- * the embedded cursor is forwarded.
+ * shape expected by the Upsun SDK. The `page_link` value is treated as an
+ * opaque continuation link from the API response; this boundary parses only the
+ * SDK fields needed to follow that link.
  */
 export function toSdkPagination(params: PaginationParams): {
   pageSize?: number;
   pageBefore?: string;
   pageAfter?: string;
 } {
-  return {
-    pageSize: params.page_size,
-    pageBefore: extractCursor(params.page_before),
-    pageAfter: extractCursor(params.page_after),
-  };
+  if (!params.page_link) {
+    return {
+      pageSize: params.page_size,
+      pageBefore: undefined,
+      pageAfter: undefined,
+    };
+  }
+
+  return extractPaginationLink(params.page_link);
 }
 
-function extractCursor(value: string | undefined): string | undefined {
-  if (!value) {
-    return value;
+function extractPaginationLink(value: string): {
+  pageSize?: number;
+  pageBefore?: string;
+  pageAfter?: string;
+} {
+  try {
+    const url = new URL(value, 'https://placeholder.invalid');
+    return {
+      pageSize: extractPageSize(url),
+      pageBefore:
+        url.searchParams.get('page[before]') ?? url.searchParams.get('pageBefore') ?? undefined,
+      pageAfter:
+        url.searchParams.get('page[after]') ?? url.searchParams.get('pageAfter') ?? undefined,
+    };
+  } catch {
+    return {
+      pageSize: undefined,
+      pageBefore: undefined,
+      pageAfter: undefined,
+    };
   }
-  // If the caller passed a URL (e.g. links.next.href), pull the cursor out.
-  if (value.includes('://') || value.startsWith('/')) {
-    try {
-      const url = new URL(value, 'https://placeholder.invalid');
-      return url.searchParams.get('pageAfter') ?? url.searchParams.get('pageBefore') ?? value;
-    } catch {
-      return value;
-    }
+}
+
+function extractPageSize(url: URL): number | undefined {
+  const rawPageSize = url.searchParams.get('page[size]') ?? url.searchParams.get('pageSize');
+  if (!rawPageSize) {
+    return undefined;
   }
-  return value;
+  const pageSize = Number(rawPageSize);
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+    return undefined;
+  }
+  return pageSize;
 }
 
 /**

--- a/upsun-mcp/src/core/helper.ts
+++ b/upsun-mcp/src/core/helper.ts
@@ -193,8 +193,8 @@ function extractPaginationLink(value: string): {
     return { pageSize: undefined, pageBefore: undefined, pageAfter: value };
   }
 
-  const pageAfter = url.searchParams.get('page[after]') ?? url.searchParams.get('pageAfter');
-  const pageBefore = url.searchParams.get('page[before]') ?? url.searchParams.get('pageBefore');
+  const pageAfter = pageParam(url, 'after');
+  const pageBefore = pageParam(url, 'before');
   const pageSize = extractPageSize(url);
 
   if (!pageAfter && !pageBefore) {
@@ -206,19 +206,22 @@ function extractPaginationLink(value: string): {
     return { pageSize, pageBefore: undefined, pageAfter: value };
   }
 
-  return {
-    pageSize,
-    pageBefore: pageBefore ?? undefined,
-    pageAfter: pageAfter ?? undefined,
-  };
+  return { pageSize, pageBefore, pageAfter };
+}
+
+// The Upsun API uses bracketed query params (`page[after]`); some SDKs emit the
+// camelCase form (`pageAfter`). Accept either.
+function pageParam(url: URL, name: 'after' | 'before' | 'size'): string | undefined {
+  const camel = `page${name[0].toUpperCase()}${name.slice(1)}`;
+  return url.searchParams.get(`page[${name}]`) ?? url.searchParams.get(camel) ?? undefined;
 }
 
 function extractPageSize(url: URL): number | undefined {
-  const rawPageSize = url.searchParams.get('page[size]') ?? url.searchParams.get('pageSize');
-  if (!rawPageSize) {
+  const raw = pageParam(url, 'size');
+  if (!raw) {
     return undefined;
   }
-  const pageSize = Number(rawPageSize);
+  const pageSize = Number(raw);
   if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
     return undefined;
   }

--- a/upsun-mcp/src/core/helper.ts
+++ b/upsun-mcp/src/core/helper.ts
@@ -118,6 +118,85 @@ export class Schema {
   static domainName(): z.ZodString {
     return z.string().max(255, 'Domain name must be less than 255 characters');
   }
+
+  /**
+   * Returns the Zod schema fields for pagination parameters supported by the
+   * Upsun API. To follow a next/previous page, take the cursor from
+   * `links.next.href` (or `links.previous.href`) in the previous response and
+   * pass it back as `page_after` or `page_before`.
+   *
+   * @returns Zod input-schema fields for cursor-based pagination.
+   */
+  static pagination(): {
+    page_size: z.ZodOptional<z.ZodNumber>;
+    page_after: z.ZodOptional<z.ZodString>;
+    page_before: z.ZodOptional<z.ZodString>;
+  } {
+    return {
+      page_size: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Number of items per page (1-100). Defaults to the API default (typically 50).'),
+      page_after: z
+        .string()
+        .optional()
+        .describe(
+          'Cursor for the next page. Use the value from `links.next.href` of the previous response.'
+        ),
+      page_before: z
+        .string()
+        .optional()
+        .describe(
+          'Cursor for the previous page. Use the value from `links.previous.href` of the previous response.'
+        ),
+    };
+  }
+}
+
+/**
+ * Pagination parameters accepted by paginatable list tools.
+ */
+export interface PaginationParams {
+  page_size?: number;
+  page_after?: string;
+  page_before?: string;
+}
+
+/**
+ * Translates MCP-style snake_case pagination params into the camelCase filter
+ * shape expected by the Upsun SDK. The `pageBefore` / `pageAfter` values may be
+ * either a bare cursor or a URL (e.g. `links.next.href`); URLs are parsed so
+ * the embedded cursor is forwarded.
+ */
+export function toSdkPagination(params: PaginationParams): {
+  pageSize?: number;
+  pageBefore?: string;
+  pageAfter?: string;
+} {
+  return {
+    pageSize: params.page_size,
+    pageBefore: extractCursor(params.page_before),
+    pageAfter: extractCursor(params.page_after),
+  };
+}
+
+function extractCursor(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+  // If the caller passed a URL (e.g. links.next.href), pull the cursor out.
+  if (value.includes('://') || value.startsWith('/')) {
+    try {
+      const url = new URL(value, 'https://placeholder.invalid');
+      return url.searchParams.get('pageAfter') ?? url.searchParams.get('pageBefore') ?? value;
+    } catch {
+      return value;
+    }
+  }
+  return value;
 }
 
 /**

--- a/upsun-mcp/src/core/helper.ts
+++ b/upsun-mcp/src/core/helper.ts
@@ -138,7 +138,7 @@ export class Schema {
         .max(100)
         .optional()
         .describe(
-          'Number of items for the first page (1-100). Defaults to the API default (typically 50).'
+          'Number of items for the first page (1-100). Defaults to the API default (typically 50). Ignored when `page_link` is set; the page size embedded in the link is used.'
         ),
       page_link: z
         .string()
@@ -185,22 +185,32 @@ function extractPaginationLink(value: string): {
   pageBefore?: string;
   pageAfter?: string;
 } {
+  let url: URL;
   try {
-    const url = new URL(value, 'https://placeholder.invalid');
-    return {
-      pageSize: extractPageSize(url),
-      pageBefore:
-        url.searchParams.get('page[before]') ?? url.searchParams.get('pageBefore') ?? undefined,
-      pageAfter:
-        url.searchParams.get('page[after]') ?? url.searchParams.get('pageAfter') ?? undefined,
-    };
+    url = new URL(value, 'https://placeholder.invalid');
   } catch {
-    return {
-      pageSize: undefined,
-      pageBefore: undefined,
-      pageAfter: undefined,
-    };
+    log.warn('Failed to parse page_link as a URL; forwarding the raw value as pageAfter');
+    return { pageSize: undefined, pageBefore: undefined, pageAfter: value };
   }
+
+  const pageAfter = url.searchParams.get('page[after]') ?? url.searchParams.get('pageAfter');
+  const pageBefore = url.searchParams.get('page[before]') ?? url.searchParams.get('pageBefore');
+  const pageSize = extractPageSize(url);
+
+  if (!pageAfter && !pageBefore) {
+    // The link is parseable but carries no recognized cursor (e.g. a bare cursor string or a
+    // URL that has been stripped of query params). Forward the raw value to the API as
+    // pageAfter so it gets a chance to honour or reject it explicitly, instead of silently
+    // re-requesting the first page.
+    log.warn('page_link has no recognized cursor parameter; forwarding the raw value as pageAfter');
+    return { pageSize, pageBefore: undefined, pageAfter: value };
+  }
+
+  return {
+    pageSize,
+    pageBefore: pageBefore ?? undefined,
+    pageAfter: pageAfter ?? undefined,
+  };
 }
 
 function extractPageSize(url: URL): number | undefined {

--- a/upsun-mcp/test/command/organization.test.ts
+++ b/upsun-mcp/test/command/organization.test.ts
@@ -160,7 +160,8 @@ describe('Organization Command Module', () => {
         'list-organization',
         {
           annotations: { readOnlyHint: true },
-          description: 'List all my organizations on upsun',
+          description:
+            'List all my organizations on upsun. Results are paginated; follow `links.next.href` via `page_after` to retrieve additional pages.',
           inputSchema: expect.any(Object),
         },
         expect.any(Function),
@@ -375,7 +376,11 @@ describe('Organization Command Module', () => {
 
       const result = await callback(params);
 
-      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith();
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith({
+        pageSize: undefined,
+        pageBefore: undefined,
+        pageAfter: undefined,
+      });
       expect(result).toEqual({
         content: [
           {
@@ -394,7 +399,11 @@ describe('Organization Command Module', () => {
 
       const result = await callback(params);
 
-      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith();
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith({
+        pageSize: undefined,
+        pageBefore: undefined,
+        pageAfter: undefined,
+      });
       expect(result).toEqual({
         content: [
           {
@@ -413,7 +422,21 @@ describe('Organization Command Module', () => {
       const params = {};
 
       await expect(callback(params)).rejects.toThrow(errorMessage);
-      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith();
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith({
+        pageSize: undefined,
+        pageBefore: undefined,
+        pageAfter: undefined,
+      });
+    });
+
+    it('should forward pagination params to the SDK', async () => {
+      const callback = toolCallbacks['list-organization'];
+      await callback({ page_size: 25, page_after: 'cursor-abc' });
+      expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith({
+        pageSize: 25,
+        pageBefore: undefined,
+        pageAfter: 'cursor-abc',
+      });
     });
 
     it('should handle large organization lists', async () => {

--- a/upsun-mcp/test/command/organization.test.ts
+++ b/upsun-mcp/test/command/organization.test.ts
@@ -161,7 +161,7 @@ describe('Organization Command Module', () => {
         {
           annotations: { readOnlyHint: true },
           description:
-            'List all my organizations on upsun. Results are paginated; follow `links.next.href` via `page_after` to retrieve additional pages.',
+            'List all my organizations on upsun. Results are paginated; pass `links.next.href` or `links.previous.href` as `page_link` to follow pages.',
           inputSchema: expect.any(Object),
         },
         expect.any(Function),
@@ -431,7 +431,9 @@ describe('Organization Command Module', () => {
 
     it('should forward pagination params to the SDK', async () => {
       const callback = toolCallbacks['list-organization'];
-      await callback({ page_size: 25, page_after: 'cursor-abc' });
+      await callback({
+        page_link: '/users/user-1/organizations?page%5Bafter%5D=cursor-abc&page%5Bsize%5D=25',
+      });
       expect(mockClient.organizations.listCurrentUserOrgs).toHaveBeenCalledWith({
         pageSize: 25,
         pageBefore: undefined,

--- a/upsun-mcp/test/command/project.test.ts
+++ b/upsun-mcp/test/command/project.test.ts
@@ -184,7 +184,11 @@ describe('Project Command Module', () => {
 
     it('lists projects successfully', async () => {
       const result = await toolCallbacks['list-project']({ organization_id: 'org-123' });
-      expect(mockClient.projects.list).toHaveBeenCalledWith('org-123');
+      expect(mockClient.projects.list).toHaveBeenCalledWith('org-123', {
+        pageSize: undefined,
+        pageBefore: undefined,
+        pageAfter: undefined,
+      });
       expect(result).toHaveProperty('content');
     });
 
@@ -199,6 +203,32 @@ describe('Project Command Module', () => {
       mockClient.projects.list.mockResolvedValueOnce([]);
       const result = await toolCallbacks['list-project']({ organization_id: 'org-123' });
       expect(result).toHaveProperty('content');
+    });
+
+    it('forwards pagination params to the SDK', async () => {
+      await toolCallbacks['list-project']({
+        organization_id: 'org-123',
+        page_size: 100,
+        page_after: 'cursor-abc',
+      });
+      expect(mockClient.projects.list).toHaveBeenCalledWith('org-123', {
+        pageSize: 100,
+        pageBefore: undefined,
+        pageAfter: 'cursor-abc',
+      });
+    });
+
+    it('extracts cursor from a next-link URL', async () => {
+      await toolCallbacks['list-project']({
+        organization_id: 'org-123',
+        page_after:
+          'https://api.upsun.com/organizations/org-123/projects?pageAfter=cursor-xyz&pageSize=50',
+      });
+      expect(mockClient.projects.list).toHaveBeenCalledWith('org-123', {
+        pageSize: undefined,
+        pageBefore: undefined,
+        pageAfter: 'cursor-xyz',
+      });
     });
   });
 

--- a/upsun-mcp/test/command/project.test.ts
+++ b/upsun-mcp/test/command/project.test.ts
@@ -209,23 +209,22 @@ describe('Project Command Module', () => {
       await toolCallbacks['list-project']({
         organization_id: 'org-123',
         page_size: 100,
-        page_after: 'cursor-abc',
       });
       expect(mockClient.projects.list).toHaveBeenCalledWith('org-123', {
         pageSize: 100,
         pageBefore: undefined,
-        pageAfter: 'cursor-abc',
+        pageAfter: undefined,
       });
     });
 
     it('extracts cursor from a next-link URL', async () => {
       await toolCallbacks['list-project']({
         organization_id: 'org-123',
-        page_after:
+        page_link:
           'https://api.upsun.com/organizations/org-123/projects?pageAfter=cursor-xyz&pageSize=50',
       });
       expect(mockClient.projects.list).toHaveBeenCalledWith('org-123', {
-        pageSize: undefined,
+        pageSize: 50,
         pageBefore: undefined,
         pageAfter: 'cursor-xyz',
       });

--- a/upsun-mcp/test/core/helper.test.ts
+++ b/upsun-mcp/test/core/helper.test.ts
@@ -365,14 +365,26 @@ describe('Helper Module', () => {
       });
     });
 
-    it('falls back to the original value when a URL has no cursor param', () => {
+    it('forwards the raw page_link as pageAfter when a URL has no cursor param', () => {
       expect(
         toSdkPagination({
           page_link: 'https://api.upsun.com/somewhere',
         })
       ).toEqual({
         pageSize: undefined,
-        pageAfter: undefined,
+        pageAfter: 'https://api.upsun.com/somewhere',
+        pageBefore: undefined,
+      });
+    });
+
+    it('forwards a bare cursor string as pageAfter', () => {
+      expect(
+        toSdkPagination({
+          page_link: 'cursor-abc',
+        })
+      ).toEqual({
+        pageSize: undefined,
+        pageAfter: 'cursor-abc',
         pageBefore: undefined,
       });
     });

--- a/upsun-mcp/test/core/helper.test.ts
+++ b/upsun-mcp/test/core/helper.test.ts
@@ -248,12 +248,14 @@ describe('Helper Module', () => {
     });
 
     describe('pagination', () => {
-      it('should expose page_size, page_after, page_before as optional fields', () => {
+      it('should expose page_size and page_link as optional fields', () => {
         const fields = Schema.pagination();
         expect(fields.page_size.parse(undefined)).toBeUndefined();
         expect(fields.page_size.parse(50)).toBe(50);
-        expect(fields.page_after.parse('cursor-abc')).toBe('cursor-abc');
-        expect(fields.page_before.parse(undefined)).toBeUndefined();
+        expect(
+          fields.page_link.parse('/organizations/org-1/projects?page%5Bafter%5D=cursor-abc')
+        ).toBe('/organizations/org-1/projects?page%5Bafter%5D=cursor-abc');
+        expect(fields.page_link.parse(undefined)).toBeUndefined();
       });
 
       it('should reject non-positive or non-integer page_size values', () => {
@@ -272,17 +274,11 @@ describe('Helper Module', () => {
   });
 
   describe('toSdkPagination', () => {
-    it('passes through bare cursor values', () => {
-      expect(
-        toSdkPagination({
-          page_size: 25,
-          page_after: 'cursor-abc',
-          page_before: 'cursor-def',
-        })
-      ).toEqual({
+    it('sets page size for first page requests', () => {
+      expect(toSdkPagination({ page_size: 25 })).toEqual({
         pageSize: 25,
-        pageAfter: 'cursor-abc',
-        pageBefore: 'cursor-def',
+        pageAfter: undefined,
+        pageBefore: undefined,
       });
     });
 
@@ -294,23 +290,73 @@ describe('Helper Module', () => {
       });
     });
 
-    it('extracts pageAfter cursor from a full URL', () => {
+    it('extracts pageAfter cursor from a full continuation link', () => {
       expect(
         toSdkPagination({
-          page_after:
+          page_link:
             'https://api.upsun.com/organizations/org-1/projects?pageAfter=cursor-xyz&pageSize=50',
         })
       ).toEqual({
-        pageSize: undefined,
+        pageSize: 50,
         pageAfter: 'cursor-xyz',
         pageBefore: undefined,
       });
     });
 
-    it('extracts pageBefore cursor from a relative URL', () => {
+    it('extracts page[after] cursor from an API next link', () => {
       expect(
         toSdkPagination({
-          page_before: '/organizations/org-1/projects?pageBefore=cursor-prev',
+          page_link:
+            'https://api.upsun.com/organizations/org-1/projects?page%5Bafter%5D=cursor-xyz&page%5Bsize%5D=50',
+        })
+      ).toEqual({
+        pageSize: 50,
+        pageAfter: 'cursor-xyz',
+        pageBefore: undefined,
+      });
+    });
+
+    it('extracts pageBefore cursor from a relative continuation link', () => {
+      expect(
+        toSdkPagination({
+          page_link: '/organizations/org-1/projects?pageBefore=cursor-prev',
+        })
+      ).toEqual({
+        pageSize: undefined,
+        pageAfter: undefined,
+        pageBefore: 'cursor-prev',
+      });
+    });
+
+    it('extracts page[size] from an API previous link', () => {
+      expect(
+        toSdkPagination({
+          page_link: '/organizations/org-1/projects?page%5Bbefore%5D=cursor-prev&page%5Bsize%5D=25',
+        })
+      ).toEqual({
+        pageSize: 25,
+        pageAfter: undefined,
+        pageBefore: 'cursor-prev',
+      });
+    });
+
+    it('follows page_link exactly when page_size is also provided', () => {
+      expect(
+        toSdkPagination({
+          page_size: 10,
+          page_link: '/organizations/org-1/projects?page%5Bafter%5D=cursor-next&page%5Bsize%5D=25',
+        })
+      ).toEqual({
+        pageSize: 25,
+        pageAfter: 'cursor-next',
+        pageBefore: undefined,
+      });
+    });
+
+    it('extracts page[before] cursor from an API previous link', () => {
+      expect(
+        toSdkPagination({
+          page_link: '/organizations/org-1/projects?page%5Bbefore%5D=cursor-prev',
         })
       ).toEqual({
         pageSize: undefined,
@@ -322,11 +368,11 @@ describe('Helper Module', () => {
     it('falls back to the original value when a URL has no cursor param', () => {
       expect(
         toSdkPagination({
-          page_after: 'https://api.upsun.com/somewhere',
+          page_link: 'https://api.upsun.com/somewhere',
         })
       ).toEqual({
         pageSize: undefined,
-        pageAfter: 'https://api.upsun.com/somewhere',
+        pageAfter: undefined,
         pageBefore: undefined,
       });
     });

--- a/upsun-mcp/test/core/helper.test.ts
+++ b/upsun-mcp/test/core/helper.test.ts
@@ -7,6 +7,7 @@ import {
   isSensitiveParam,
   SENSITIVE_PARAM_KEYWORDS,
   forwardUpstream401,
+  toSdkPagination,
 } from '../../src/core/helper';
 import { z } from 'zod';
 import { ResponseError } from 'upsun-sdk-node/dist/core/runtime.js';
@@ -243,6 +244,90 @@ describe('Helper Module', () => {
         expect(() => schema.parse(123)).toThrow();
         expect(() => schema.parse(null)).toThrow();
         expect(() => schema.parse(undefined)).toThrow();
+      });
+    });
+
+    describe('pagination', () => {
+      it('should expose page_size, page_after, page_before as optional fields', () => {
+        const fields = Schema.pagination();
+        expect(fields.page_size.parse(undefined)).toBeUndefined();
+        expect(fields.page_size.parse(50)).toBe(50);
+        expect(fields.page_after.parse('cursor-abc')).toBe('cursor-abc');
+        expect(fields.page_before.parse(undefined)).toBeUndefined();
+      });
+
+      it('should reject non-positive or non-integer page_size values', () => {
+        const fields = Schema.pagination();
+        expect(() => fields.page_size.parse(0)).toThrow();
+        expect(() => fields.page_size.parse(-1)).toThrow();
+        expect(() => fields.page_size.parse(1.5)).toThrow();
+      });
+
+      it('should reject page_size values above the API maximum of 100', () => {
+        const fields = Schema.pagination();
+        expect(fields.page_size.parse(100)).toBe(100);
+        expect(() => fields.page_size.parse(101)).toThrow();
+      });
+    });
+  });
+
+  describe('toSdkPagination', () => {
+    it('passes through bare cursor values', () => {
+      expect(
+        toSdkPagination({
+          page_size: 25,
+          page_after: 'cursor-abc',
+          page_before: 'cursor-def',
+        })
+      ).toEqual({
+        pageSize: 25,
+        pageAfter: 'cursor-abc',
+        pageBefore: 'cursor-def',
+      });
+    });
+
+    it('returns undefined for missing values', () => {
+      expect(toSdkPagination({})).toEqual({
+        pageSize: undefined,
+        pageAfter: undefined,
+        pageBefore: undefined,
+      });
+    });
+
+    it('extracts pageAfter cursor from a full URL', () => {
+      expect(
+        toSdkPagination({
+          page_after:
+            'https://api.upsun.com/organizations/org-1/projects?pageAfter=cursor-xyz&pageSize=50',
+        })
+      ).toEqual({
+        pageSize: undefined,
+        pageAfter: 'cursor-xyz',
+        pageBefore: undefined,
+      });
+    });
+
+    it('extracts pageBefore cursor from a relative URL', () => {
+      expect(
+        toSdkPagination({
+          page_before: '/organizations/org-1/projects?pageBefore=cursor-prev',
+        })
+      ).toEqual({
+        pageSize: undefined,
+        pageAfter: undefined,
+        pageBefore: 'cursor-prev',
+      });
+    });
+
+    it('falls back to the original value when a URL has no cursor param', () => {
+      expect(
+        toSdkPagination({
+          page_after: 'https://api.upsun.com/somewhere',
+        })
+      ).toEqual({
+        pageSize: undefined,
+        pageAfter: 'https://api.upsun.com/somewhere',
+        pageBefore: undefined,
       });
     });
   });


### PR DESCRIPTION
## Summary

- The Upsun API paginates the projects and user-organizations endpoints, defaulting to 50 items per page. The MCP tools previously hid this entirely, capping output at the first page and dropping the `_links.next` cursor needed for follow-on requests.
- Expose two pagination params on `list-project` and `list-organization`:
  - `page_size` — bounded to [1, 100] to match the API's documented maximum. Used for the first request; ignored when `page_link` is set (the link's embedded page size wins).
  - `page_link` — opaque continuation link. Pass `_links.next.href` or `_links.previous.href` from a previous response verbatim. The MCP server parses the URL at the boundary and forwards the `page[after]` / `page[before]` cursor (and embedded `page[size]`) to the SDK.
- A single opaque link is simpler than exposing the cursor params directly, matches the OpenAPI guidance that cursors should not be constructed externally, and matches how callers think about following pagination links.
- If `page_link` cannot be parsed, or is parseable but carries no recognized cursor (e.g. a bare cursor string, or a URL stripped of query params), the raw value is forwarded as `pageAfter` and a warning is logged. This avoids the silent degradation where a malformed link would otherwise re-request page 1.

Other `list-*` tools (`list-environment`, `list-activity`, `list-backup`, `list-domain`, `list-certificate`, `list-route`) hit endpoints that take no pagination params in the OpenAPI spec, so they are unaffected.

Closes [AI-189: Support pagination parameters to return more than 50 items](https://linear.app/platformsh/issue/AI-189/support-pagination-parameters-to-return-more-than-50-items)