### PR TITLE
fix(auth): bind MCP sessions to the credential token hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,15 +129,21 @@ upsun-mcp/
 1. **API Key**: Direct authentication via `upsun-api-token` header
 2. **Bearer Token**: Alternative authentication via `Authorization: Bearer` header
 3. **Write Control**: Write operations controlled via `enable-write` header
-4. **Session ownership binding**: Each session is bound to the principal that created it.
-   API-key sessions store a SHA-256 hash of the key; bearer sessions store only the
-   authentication type. Every request that reuses an existing `mcp-session-id` must
-   authenticate as the same principal (`authMatchesSessionOwner` in
-   `core/authentication.ts`): the authentication type must match, and an API-key request
-   must present the same key. Mismatches receive 401. The upstream client is always
-   rebound to the token presented on the current request, so a call never executes
-   against a stored credential. This applies to the HTTP POST/GET/DELETE handlers and the
-   SSE message handler.
+4. **Session token binding**: Each session is bound to the exact credential token that
+   created it. The session stores a SHA-256 hash of that token (`sessionOwnerFromAuth`
+   in `core/authentication.ts`), and every request that reuses an existing
+   `mcp-session-id` must present a token with the same hash (`authMatchesSessionOwner`,
+   constant-time compared). Because the binding is to the token rather than to a claim,
+   it holds without verifying the JWT signature: a leaked `mcp-session-id` is useless
+   without the token, and anyone holding the token already has the access the session
+   would grant. A request whose token does not match — including an unknown session id —
+   receives `404 Session not found` (the two are indistinguishable, so the id cannot be
+   used to probe for live sessions); a compliant client responds by starting a new
+   session, which also covers the case of an OAuth access token having been refreshed.
+   This applies to the HTTP POST/GET/DELETE handlers and the SSE message handler. Because
+   a bearer session cannot outlive its token, HTTP sessions are evicted at the token's
+   `exp` so that refreshed-out sessions do not accumulate; API keys carry no expiry and
+   their sessions live until the transport closes.
 5. **Upstream 401 forwarding**: When the Upsun API returns 401 (expired/revoked token),
    the HTTP transport forwards the 401 status and `WWW-Authenticate` header directly to
    the MCP client so it can trigger OAuth2 token refresh. This only works on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,16 @@ upsun-mcp/
 1. **API Key**: Direct authentication via `upsun-api-token` header
 2. **Bearer Token**: Alternative authentication via `Authorization: Bearer` header
 3. **Write Control**: Write operations controlled via `enable-write` header
-4. **Upstream 401 forwarding**: When the Upsun API returns 401 (expired/revoked token),
+4. **Session ownership binding**: Each session is bound to the principal that created it.
+   API-key sessions store a SHA-256 hash of the key; bearer sessions store only the
+   authentication type. Every request that reuses an existing `mcp-session-id` must
+   authenticate as the same principal (`authMatchesSessionOwner` in
+   `core/authentication.ts`): the authentication type must match, and an API-key request
+   must present the same key. Mismatches receive 401. The upstream client is always
+   rebound to the token presented on the current request, so a call never executes
+   against a stored credential. This applies to the HTTP POST/GET/DELETE handlers and the
+   SSE message handler.
+5. **Upstream 401 forwarding**: When the Upsun API returns 401 (expired/revoked token),
    the HTTP transport forwards the 401 status and `WWW-Authenticate` header directly to
    the MCP client so it can trigger OAuth2 token refresh. This only works on the
    Streamable HTTP transport (`enableJsonResponse: true`); SSE commits 200 headers

--- a/upsun-mcp/src/core/adapter.ts
+++ b/upsun-mcp/src/core/adapter.ts
@@ -25,20 +25,6 @@ export interface McpAdapter {
   readonly client: UpsunClient;
 
   /**
-   * The current bearer token for the active request.
-   * This is set by the gateway for each request and used by tools to create fresh clients.
-   */
-  currentBearerToken?: string;
-
-  /**
-   * Sets the current bearer token for this adapter instance.
-   * This is called by the gateway before each tool invocation.
-   *
-   * @param token - The bearer token to set as current
-   */
-  setCurrentBearerToken(token: string): void;
-
-  /**
    * Establishes a connection between the MCP server and transport layer using a Bearer token.
    *
    * This method initializes the MCP server with the provided transport and

--- a/upsun-mcp/src/core/authentication.ts
+++ b/upsun-mcp/src/core/authentication.ts
@@ -1,4 +1,5 @@
 import express, { RequestHandler } from 'express';
+import { createHash, timingSafeEqual } from 'crypto';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { createLogger } from './logger.js';
@@ -202,6 +203,67 @@ export function requireMcpAuth(
     }
     bearerAuth(req, res, next);
   };
+}
+
+/**
+ * Identity of the principal that created an MCP session.
+ *
+ * A session is bound to its creator so that later requests reusing the same
+ * `mcp-session-id` cannot drive it as a different principal. API-key sessions
+ * store a hash of the key (a stable secret) for an exact match; bearer sessions
+ * store only the type because the access token rotates on refresh and the
+ * presented token is rebound on every request.
+ */
+export type SessionOwner = { authType: 'bearer' } | { authType: 'api-key'; keyHash: string };
+
+function hashApiKey(key: string): Buffer {
+  return createHash('sha256').update(key).digest();
+}
+
+/**
+ * Derives the session owner identity from the authenticated request.
+ */
+export function sessionOwnerFromAuth(auth: AuthInfo): SessionOwner {
+  if (auth.clientId === API_KEY_CLIENT_ID) {
+    return { authType: 'api-key', keyHash: hashApiKey(auth.token).toString('hex') };
+  }
+  return { authType: 'bearer' };
+}
+
+/**
+ * Reports whether an authenticated request may reuse a session owned by the
+ * given principal.
+ *
+ * The authentication type must match. For API-key sessions the presented key
+ * must hash to the same value as the creator's. For bearer sessions any bearer
+ * request is allowed because the caller rebinds the upstream client to the
+ * presented token before dispatch, so a request never executes against a
+ * stored credential; the token itself is validated upstream by the Upsun API.
+ */
+export function authMatchesSessionOwner(auth: AuthInfo, owner: SessionOwner): boolean {
+  const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
+  if (owner.authType === 'api-key') {
+    if (!isApiKey) {
+      return false;
+    }
+    const presented = hashApiKey(auth.token);
+    const expected = Buffer.from(owner.keyHash, 'hex');
+    return presented.length === expected.length && timingSafeEqual(presented, expected);
+  }
+  return !isApiKey;
+}
+
+/**
+ * Sends a 401 response for a request that authenticates successfully but is not
+ * permitted to act on the targeted session. The `WWW-Authenticate` header lets
+ * an OAuth client re-authenticate. The message is intentionally generic and
+ * does not confirm whether the session exists.
+ */
+export function rejectUnauthorized(res: express.Response): void {
+  res
+    .status(401)
+    .set('WWW-Authenticate', 'Bearer error="invalid_token"')
+    .json({ error: 'invalid_token', message: 'Unauthorized' });
 }
 
 /**

--- a/upsun-mcp/src/core/authentication.ts
+++ b/upsun-mcp/src/core/authentication.ts
@@ -206,64 +206,53 @@ export function requireMcpAuth(
 }
 
 /**
- * Identity of the principal that created an MCP session.
+ * Identity of the principal that created an MCP session: a hex SHA-256 of the
+ * credential token presented at creation (an OAuth bearer JWT or an API key).
  *
- * A session is bound to its creator so that later requests reusing the same
- * `mcp-session-id` cannot drive it as a different principal. API-key sessions
- * store a hash of the key (a stable secret) for an exact match; bearer sessions
- * store only the type because the access token rotates on refresh and the
- * presented token is rebound on every request.
+ * A session is bound to the exact token that created it. Binding to the token
+ * rather than to a claim means the guarantee holds without verifying the JWT
+ * signature: someone who learns a session id cannot drive the session without
+ * also presenting the same token, and anyone holding that token already has the
+ * access the session would grant. When an OAuth token is refreshed the new
+ * token no longer matches, so the client transparently starts a new session.
  */
-export type SessionOwner = { authType: 'bearer' } | { authType: 'api-key'; keyHash: string };
+export type SessionOwner = string;
 
-function hashApiKey(key: string): Buffer {
-  return createHash('sha256').update(key).digest();
+function hashToken(token: string): Buffer {
+  return createHash('sha256').update(token).digest();
 }
 
 /**
- * Derives the session owner identity from the authenticated request.
+ * Derives the session owner from the authenticated request.
  */
 export function sessionOwnerFromAuth(auth: AuthInfo): SessionOwner {
-  if (auth.clientId === API_KEY_CLIENT_ID) {
-    return { authType: 'api-key', keyHash: hashApiKey(auth.token).toString('hex') };
-  }
-  return { authType: 'bearer' };
+  return hashToken(auth.token).toString('hex');
 }
 
 /**
- * Reports whether an authenticated request may reuse a session owned by the
- * given principal.
- *
- * The authentication type must match. For API-key sessions the presented key
- * must hash to the same value as the creator's. For bearer sessions any bearer
- * request is allowed because the caller rebinds the upstream client to the
- * presented token before dispatch, so a request never executes against a
- * stored credential; the token itself is validated upstream by the Upsun API.
+ * Reports whether a request presents the same token that created the session,
+ * using a constant-time comparison of the token hashes.
  */
 export function authMatchesSessionOwner(auth: AuthInfo, owner: SessionOwner): boolean {
-  const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
-  if (owner.authType === 'api-key') {
-    if (!isApiKey) {
-      return false;
-    }
-    const presented = hashApiKey(auth.token);
-    const expected = Buffer.from(owner.keyHash, 'hex');
-    return presented.length === expected.length && timingSafeEqual(presented, expected);
-  }
-  return !isApiKey;
+  const presented = hashToken(auth.token);
+  const expected = Buffer.from(owner, 'hex');
+  return presented.length === expected.length && timingSafeEqual(presented, expected);
 }
 
 /**
- * Sends a 401 response for a request that authenticates successfully but is not
- * permitted to act on the targeted session. The `WWW-Authenticate` header lets
- * an OAuth client re-authenticate. The message is intentionally generic and
- * does not confirm whether the session exists.
+ * Sends the "session not found" response (HTTP 404) used when a request targets
+ * a session that does not exist or whose binding token does not match. The two
+ * cases are deliberately indistinguishable so a session id cannot be used to
+ * probe for live sessions. A compliant MCP client responds by starting a new
+ * session with a fresh `initialize` request, which covers the legitimate case
+ * of an OAuth access token having been refreshed.
  */
-export function rejectUnauthorized(res: express.Response): void {
-  res
-    .status(401)
-    .set('WWW-Authenticate', 'Bearer error="invalid_token"')
-    .json({ error: 'invalid_token', message: 'Unauthorized' });
+export function rejectSessionNotFound(res: express.Response): void {
+  res.status(404).json({
+    jsonrpc: '2.0',
+    error: { code: -32001, message: 'Session not found' },
+    id: null,
+  });
 }
 
 /**

--- a/upsun-mcp/src/core/transport/http.ts
+++ b/upsun-mcp/src/core/transport/http.ts
@@ -9,8 +9,15 @@ import express from 'express';
 
 import { McpAdapter } from '../adapter.js';
 import { createLogger } from '../logger.js';
-import { extractMode, HeaderKey, API_KEY_CLIENT_ID } from '../authentication.js';
-import type { AuthInfo } from '../authentication.js';
+import {
+  extractMode,
+  HeaderKey,
+  API_KEY_CLIENT_ID,
+  sessionOwnerFromAuth,
+  authMatchesSessionOwner,
+  rejectUnauthorized,
+} from '../authentication.js';
+import type { AuthInfo, SessionOwner } from '../authentication.js';
 import { GatewayServer } from '../gateway.js';
 import { requestContext } from '../requestContext.js';
 
@@ -20,7 +27,7 @@ export class HttpTransport {
   /** Active streamable HTTP server transports (protocol version 2025-03-26) */
   readonly streamable = {} as Record<
     string,
-    { transport: StreamableHTTPServerTransport; server: McpAdapter }
+    { transport: StreamableHTTPServerTransport; server: McpAdapter; owner: SessionOwner }
   >;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,9 +54,18 @@ export class HttpTransport {
     const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
 
     if (sessionId && this.streamable[sessionId]) {
-      // Reuse existing transport - inject fresh authentication token.
-      const { transport, server } = this.streamable[sessionId];
+      // Reuse existing transport. The session is bound to its creator, so a
+      // request reusing the session must authenticate as the same principal.
+      const { transport, server, owner } = this.streamable[sessionId];
 
+      if (!authMatchesSessionOwner(auth, owner)) {
+        httpLog.warn('Rejecting session reuse: request principal does not own the session');
+        rejectUnauthorized(res);
+        return;
+      }
+
+      // Rebind the upstream client to the token presented on this request so a
+      // call never executes against a stored credential.
       if (!isApiKey) {
         httpLog.debug('Bearer token found for existing session, updating server');
         server.setCurrentBearerToken(auth.token);
@@ -68,7 +84,7 @@ export class HttpTransport {
         sessionIdGenerator: (): string => randomUUID(),
         enableJsonResponse: true,
         onsessioninitialized: (sessionId): void => {
-          this.streamable[sessionId] = { transport, server };
+          this.streamable[sessionId] = { transport, server, owner: sessionOwnerFromAuth(auth) };
         },
       });
 
@@ -110,13 +126,26 @@ export class HttpTransport {
   async handleSessionRequest(req: express.Request, res: express.Response): Promise<void> {
     httpLog.info('Received GET/DELETE request to /mcp (Streamable transport)');
 
+    const auth = req.auth as AuthInfo | undefined;
+    if (!auth) {
+      res
+        .status(500)
+        .json({ error: 'server_error', message: 'Authentication middleware did not run' });
+      return;
+    }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
     if (!sessionId || !this.streamable[sessionId]) {
       res.status(400).send('Invalid or missing session ID');
       return;
     }
 
-    const { transport } = this.streamable[sessionId];
+    const { transport, owner } = this.streamable[sessionId];
+    if (!authMatchesSessionOwner(auth, owner)) {
+      httpLog.warn('Rejecting session request: request principal does not own the session');
+      rejectUnauthorized(res);
+      return;
+    }
+
     await transport.handleRequest(req, res);
   }
 

--- a/upsun-mcp/src/core/transport/http.ts
+++ b/upsun-mcp/src/core/transport/http.ts
@@ -55,8 +55,6 @@ export class HttpTransport {
       return;
     }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
-    const mode = extractMode(req);
-    const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
 
     if (sessionId) {
       // The session is bound to the token that created it. A request that does
@@ -78,6 +76,8 @@ export class HttpTransport {
     if (isInitializeRequest(req.body)) {
       httpLog.info('New session initialization request');
 
+      const mode = extractMode(req);
+      const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
       const server = this.gateway.makeInstanceAdapterMcpServer(mode);
 
       // enableJsonResponse defers writing HTTP headers until the handler completes,

--- a/upsun-mcp/src/core/transport/http.ts
+++ b/upsun-mcp/src/core/transport/http.ts
@@ -15,7 +15,7 @@ import {
   API_KEY_CLIENT_ID,
   sessionOwnerFromAuth,
   authMatchesSessionOwner,
-  rejectUnauthorized,
+  rejectSessionNotFound,
 } from '../authentication.js';
 import type { AuthInfo, SessionOwner } from '../authentication.js';
 import { GatewayServer } from '../gateway.js';
@@ -27,7 +27,12 @@ export class HttpTransport {
   /** Active streamable HTTP server transports (protocol version 2025-03-26) */
   readonly streamable = {} as Record<
     string,
-    { transport: StreamableHTTPServerTransport; server: McpAdapter; owner: SessionOwner }
+    {
+      transport: StreamableHTTPServerTransport;
+      server: McpAdapter;
+      owner: SessionOwner;
+      expiryTimer?: NodeJS.Timeout;
+    }
   >;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,26 +58,24 @@ export class HttpTransport {
     const mode = extractMode(req);
     const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
 
-    if (sessionId && this.streamable[sessionId]) {
-      // Reuse existing transport. The session is bound to its creator, so a
-      // request reusing the session must authenticate as the same principal.
-      const { transport, server, owner } = this.streamable[sessionId];
-
-      if (!authMatchesSessionOwner(auth, owner)) {
-        httpLog.warn('Rejecting session reuse: request principal does not own the session');
-        rejectUnauthorized(res);
+    if (sessionId) {
+      // The session is bound to the token that created it. A request that does
+      // not present that token is treated as if the session does not exist, so
+      // an unknown id and a wrong token are indistinguishable to the caller.
+      const session = this.streamable[sessionId];
+      if (!session || !authMatchesSessionOwner(auth, session.owner)) {
+        httpLog.warn('Rejecting session reuse: unknown session id or non-matching token');
+        rejectSessionNotFound(res);
         return;
       }
 
-      // Rebind the upstream client to the token presented on this request so a
-      // call never executes against a stored credential.
-      if (!isApiKey) {
-        httpLog.debug('Bearer token found for existing session, updating server');
-        server.setCurrentBearerToken(auth.token);
-      }
+      // No credential rebind is needed: reuse only succeeds for the same token,
+      // which the session's client is already bound to.
+      await requestContext.run({ res }, () => session.transport.handleRequest(req, res, req.body));
+      return;
+    }
 
-      await requestContext.run({ res }, () => transport.handleRequest(req, res, req.body));
-    } else if (!sessionId && isInitializeRequest(req.body)) {
+    if (isInitializeRequest(req.body)) {
       httpLog.info('New session initialization request');
 
       const server = this.gateway.makeInstanceAdapterMcpServer(mode);
@@ -85,12 +88,15 @@ export class HttpTransport {
         enableJsonResponse: true,
         onsessioninitialized: (sessionId): void => {
           this.streamable[sessionId] = { transport, server, owner: sessionOwnerFromAuth(auth) };
+          // Bound to the creating token, the session cannot outlive it; evict at
+          // the token's expiry so refreshed-out sessions do not accumulate.
+          this.scheduleExpiry(sessionId, auth.expiresAt);
         },
       });
 
       transport.onclose = (): void => {
         if (transport.sessionId) {
-          delete this.streamable[transport.sessionId];
+          this.deleteSession(transport.sessionId);
         }
       };
 
@@ -104,16 +110,61 @@ export class HttpTransport {
       }
 
       await requestContext.run({ res }, () => transport.handleRequest(req, res, req.body));
-    } else {
-      res.status(400).json({
-        jsonrpc: '2.0',
-        error: {
-          code: -32000,
-          message: 'Bad Request: No valid session ID provided',
-        },
-        id: null,
-      });
       return;
+    }
+
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Bad Request: No valid session ID provided',
+      },
+      id: null,
+    });
+  }
+
+  /**
+   * Schedules eviction of a session when its credential token expires. API-key
+   * tokens carry no expiry, so those sessions live until the transport closes.
+   */
+  private scheduleExpiry(sessionId: string, expiresAt?: number): void {
+    if (expiresAt === undefined) {
+      return;
+    }
+    const session = this.streamable[sessionId];
+    if (!session) {
+      return;
+    }
+    const delayMs = Math.max(0, expiresAt * 1000 - Date.now());
+    const timer = setTimeout(() => {
+      httpLog.info(`Session ${sessionId} reached token expiry; closing`);
+      void this.closeSession(sessionId);
+    }, delayMs);
+    // Do not keep the process alive solely to fire this timer.
+    timer.unref?.();
+    session.expiryTimer = timer;
+  }
+
+  /** Removes a session from the map and clears its expiry timer. */
+  private deleteSession(sessionId: string): void {
+    const session = this.streamable[sessionId];
+    if (session?.expiryTimer) {
+      clearTimeout(session.expiryTimer);
+    }
+    delete this.streamable[sessionId];
+  }
+
+  /** Closes a session's transport, which triggers cleanup via onclose. */
+  private async closeSession(sessionId: string): Promise<void> {
+    const session = this.streamable[sessionId];
+    if (!session) {
+      return;
+    }
+    try {
+      await session.transport.close();
+    } catch (error) {
+      httpLog.error(`Error closing transport streamable for session ${sessionId}:`, error);
+      this.deleteSession(sessionId);
     }
   }
 
@@ -134,19 +185,20 @@ export class HttpTransport {
       return;
     }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
-    if (!sessionId || !this.streamable[sessionId]) {
+    if (!sessionId) {
       res.status(400).send('Invalid or missing session ID');
       return;
     }
 
-    const { transport, owner } = this.streamable[sessionId];
-    if (!authMatchesSessionOwner(auth, owner)) {
-      httpLog.warn('Rejecting session request: request principal does not own the session');
-      rejectUnauthorized(res);
+    // Unknown id and non-matching token are treated alike (see postSessionRequest).
+    const session = this.streamable[sessionId];
+    if (!session || !authMatchesSessionOwner(auth, session.owner)) {
+      httpLog.warn('Rejecting session request: unknown session id or non-matching token');
+      rejectSessionNotFound(res);
       return;
     }
 
-    await transport.handleRequest(req, res);
+    await session.transport.handleRequest(req, res);
   }
 
   async closeAllSessions(): Promise<void> {
@@ -154,7 +206,7 @@ export class HttpTransport {
       try {
         httpLog.info(`Closing transport for session ${sessionId}`);
         const session = this.streamable[sessionId];
-        delete this.streamable[sessionId];
+        this.deleteSession(sessionId);
         await session.transport.close();
       } catch (error) {
         httpLog.error(`Error closing transport streamable for session ${sessionId}:`, error);

--- a/upsun-mcp/src/core/transport/sse.ts
+++ b/upsun-mcp/src/core/transport/sse.ts
@@ -3,8 +3,14 @@ import { McpAdapter } from '../adapter.js';
 import express from 'express';
 import { GatewayServer } from '../gateway.js';
 import { createLogger } from '../logger.js';
-import { extractMode, API_KEY_CLIENT_ID } from '../authentication.js';
-import type { AuthInfo } from '../authentication.js';
+import {
+  extractMode,
+  API_KEY_CLIENT_ID,
+  sessionOwnerFromAuth,
+  authMatchesSessionOwner,
+  rejectUnauthorized,
+} from '../authentication.js';
+import type { AuthInfo, SessionOwner } from '../authentication.js';
 
 const sseLog = createLogger('Web:SSE');
 
@@ -18,7 +24,10 @@ export const HTTP_MSG_PATH = '/messages';
 // commits HTTP 200 headers as soon as the connection is established.
 export class SseTransport {
   /** Active SSE server transports (protocol version 2024-11-05) */
-  readonly sse = {} as Record<string, { transport: SSEServerTransport; server: McpAdapter }>;
+  readonly sse = {} as Record<
+    string,
+    { transport: SSEServerTransport; server: McpAdapter; owner: SessionOwner }
+  >;
 
   /**
    * Active SSE connections with their keep-alive intervals.
@@ -52,9 +61,18 @@ export class SseTransport {
     const transportSession = this.sse[sessionId];
 
     if (transportSession) {
-      const { transport, server } = transportSession;
+      const { transport, server, owner } = transportSession;
 
-      // Update the server with fresh bearer token.
+      // The session is bound to its creator; a request reusing it must
+      // authenticate as the same principal.
+      if (!authMatchesSessionOwner(auth, owner)) {
+        sseLog.warn(`Rejecting message from ${ip}: request principal does not own the session`);
+        rejectUnauthorized(res);
+        return;
+      }
+
+      // Rebind the upstream client to the token presented on this request so a
+      // call never executes against a stored credential.
       if (auth.clientId !== API_KEY_CLIENT_ID) {
         server.setCurrentBearerToken(auth.token);
       }
@@ -85,7 +103,7 @@ export class SseTransport {
 
     const server = this.gateway.makeInstanceAdapterMcpServer(mode);
 
-    this.sse[transport.sessionId] = { transport, server };
+    this.sse[transport.sessionId] = { transport, server, owner: sessionOwnerFromAuth(auth) };
 
     // Start keep-alive ping.
     const intervalId = setInterval(() => {

--- a/upsun-mcp/src/core/transport/sse.ts
+++ b/upsun-mcp/src/core/transport/sse.ts
@@ -8,7 +8,7 @@ import {
   API_KEY_CLIENT_ID,
   sessionOwnerFromAuth,
   authMatchesSessionOwner,
-  rejectUnauthorized,
+  rejectSessionNotFound,
 } from '../authentication.js';
 import type { AuthInfo, SessionOwner } from '../authentication.js';
 
@@ -60,28 +60,17 @@ export class SseTransport {
     const sessionId = req.query.sessionId as string;
     const transportSession = this.sse[sessionId];
 
-    if (transportSession) {
-      const { transport, server, owner } = transportSession;
-
-      // The session is bound to its creator; a request reusing it must
-      // authenticate as the same principal.
-      if (!authMatchesSessionOwner(auth, owner)) {
-        sseLog.warn(`Rejecting message from ${ip}: request principal does not own the session`);
-        rejectUnauthorized(res);
-        return;
-      }
-
-      // Rebind the upstream client to the token presented on this request so a
-      // call never executes against a stored credential.
-      if (auth.clientId !== API_KEY_CLIENT_ID) {
-        server.setCurrentBearerToken(auth.token);
-      }
-
-      sseLog.info(`Message call from ${ip} with ID: ${transport.sessionId}`);
-      await transport.handlePostMessage(req, res, req.body);
-    } else {
-      res.status(400).send('No transport found for sessionId');
+    // The session is bound to the token that created it. An unknown id and a
+    // non-matching token are treated alike, so neither reveals a live session.
+    if (!transportSession || !authMatchesSessionOwner(auth, transportSession.owner)) {
+      sseLog.warn(`Rejecting message from ${ip}: unknown session id or non-matching token`);
+      rejectSessionNotFound(res);
+      return;
     }
+
+    const { transport } = transportSession;
+    sseLog.info(`Message call from ${ip} with ID: ${transport.sessionId}`);
+    await transport.handlePostMessage(req, res, req.body);
   }
 
   async getSessionRequest(req: express.Request, res: express.Response): Promise<void> {

--- a/upsun-mcp/src/mcpUpsun.ts
+++ b/upsun-mcp/src/mcpUpsun.ts
@@ -49,12 +49,6 @@ export class UpsunMcpServer implements McpAdapter {
   public client!: UpsunClient;
 
   /**
-   * The current bearer token for the active request.
-   * This is set by the gateway for each request and used by tools to create fresh clients.
-   */
-  public currentBearerToken?: string;
-
-  /**
    * Creates a new UpsunMcpServer instance.
    *
    * Initializes the MCP server with the package name and version, then registers
@@ -89,22 +83,6 @@ export class UpsunMcpServer implements McpAdapter {
 
     // Register all tasks with their respective prompts
     registerConfig(this);
-  }
-
-  /**
-   * Sets the current bearer token for this adapter instance.
-   * This is called by the gateway before each tool invocation.
-   *
-   * @param token - The bearer token to set as current
-   *
-   * @example
-   * ```typescript
-   * server.setCurrentBearerToken('your-bearer-token');
-   * ```
-   */
-  setCurrentBearerToken(token: string): void {
-    this.currentBearerToken = token;
-    this.client.setBearerToken(token);
   }
 
   /**

--- a/upsun-mcp/test/core/authentication.test.ts
+++ b/upsun-mcp/test/core/authentication.test.ts
@@ -332,43 +332,31 @@ describe('Authentication Module', () => {
       scopes: [],
     });
 
-    it('derives a bearer owner from a bearer request', () => {
-      expect(sessionOwnerFromAuth(bearer('jwt'))).toEqual({ authType: 'bearer' });
+    it('derives the owner as a hex SHA-256 that does not leak the token', () => {
+      const owner = sessionOwnerFromAuth(bearer('secret-token'));
+      expect(owner).toMatch(/^[0-9a-f]{64}$/);
+      expect(owner).not.toContain('secret-token');
     });
 
-    it('derives an api-key owner with a key hash from an api-key request', () => {
-      const owner = sessionOwnerFromAuth(apiKey('secret-key'));
-      expect(owner.authType).toBe('api-key');
-      if (owner.authType === 'api-key') {
-        expect(owner.keyHash).toMatch(/^[0-9a-f]{64}$/);
-        // The raw key must not be stored.
-        expect(owner.keyHash).not.toContain('secret-key');
-      }
+    it('matches when the same token is presented again', () => {
+      const owner = sessionOwnerFromAuth(bearer('jwt-abc'));
+      expect(authMatchesSessionOwner(bearer('jwt-abc'), owner)).toBe(true);
     });
 
-    it('allows a bearer request to reuse a bearer session', () => {
+    it('matches the same key regardless of how clientId is labelled', () => {
+      // The binding is to the token bytes, not the authentication type.
+      const owner = sessionOwnerFromAuth(apiKey('shared-secret'));
+      expect(authMatchesSessionOwner(bearer('shared-secret'), owner)).toBe(true);
+    });
+
+    it('rejects a different bearer token (e.g. a refreshed or attacker token)', () => {
       const owner = sessionOwnerFromAuth(bearer('jwt-1'));
-      expect(authMatchesSessionOwner(bearer('jwt-2-refreshed'), owner)).toBe(true);
+      expect(authMatchesSessionOwner(bearer('jwt-2-refreshed'), owner)).toBe(false);
     });
 
-    it('rejects an api-key request against a bearer session', () => {
-      const owner = sessionOwnerFromAuth(bearer('jwt'));
-      expect(authMatchesSessionOwner(apiKey('anything'), owner)).toBe(false);
-    });
-
-    it('allows an api-key request with the matching key', () => {
-      const owner = sessionOwnerFromAuth(apiKey('the-key'));
-      expect(authMatchesSessionOwner(apiKey('the-key'), owner)).toBe(true);
-    });
-
-    it('rejects an api-key request with a different key', () => {
+    it('rejects a different api key', () => {
       const owner = sessionOwnerFromAuth(apiKey('victim-key'));
       expect(authMatchesSessionOwner(apiKey('attacker-key'), owner)).toBe(false);
-    });
-
-    it('rejects a bearer request against an api-key session', () => {
-      const owner = sessionOwnerFromAuth(apiKey('the-key'));
-      expect(authMatchesSessionOwner(bearer('jwt'), owner)).toBe(false);
     });
   });
 });

--- a/upsun-mcp/test/core/authentication.test.ts
+++ b/upsun-mcp/test/core/authentication.test.ts
@@ -10,7 +10,10 @@ import {
   JwtTokenVerifier,
   requireMcpAuth,
   API_KEY_CLIENT_ID,
+  sessionOwnerFromAuth,
+  authMatchesSessionOwner,
 } from '../../src/core/authentication';
+import type { AuthInfo } from '../../src/core/authentication';
 
 /** Builds a minimal unsigned JWT with the given payload. */
 function makeJwt(payload: Record<string, unknown>): string {
@@ -318,6 +321,54 @@ describe('Authentication Module', () => {
       const calls = getSpy.mock.calls.map(c => c[0]);
       expect(calls).not.toContain('/.well-known/oauth-authorization-server/mcp');
       expect(calls).not.toContain('/.well-known/oauth-protected-resource/mcp');
+    });
+  });
+
+  describe('Session ownership binding', () => {
+    const bearer = (token: string): AuthInfo => ({ token, clientId: 'user-1', scopes: [] });
+    const apiKey = (token: string): AuthInfo => ({
+      token,
+      clientId: API_KEY_CLIENT_ID,
+      scopes: [],
+    });
+
+    it('derives a bearer owner from a bearer request', () => {
+      expect(sessionOwnerFromAuth(bearer('jwt'))).toEqual({ authType: 'bearer' });
+    });
+
+    it('derives an api-key owner with a key hash from an api-key request', () => {
+      const owner = sessionOwnerFromAuth(apiKey('secret-key'));
+      expect(owner.authType).toBe('api-key');
+      if (owner.authType === 'api-key') {
+        expect(owner.keyHash).toMatch(/^[0-9a-f]{64}$/);
+        // The raw key must not be stored.
+        expect(owner.keyHash).not.toContain('secret-key');
+      }
+    });
+
+    it('allows a bearer request to reuse a bearer session', () => {
+      const owner = sessionOwnerFromAuth(bearer('jwt-1'));
+      expect(authMatchesSessionOwner(bearer('jwt-2-refreshed'), owner)).toBe(true);
+    });
+
+    it('rejects an api-key request against a bearer session', () => {
+      const owner = sessionOwnerFromAuth(bearer('jwt'));
+      expect(authMatchesSessionOwner(apiKey('anything'), owner)).toBe(false);
+    });
+
+    it('allows an api-key request with the matching key', () => {
+      const owner = sessionOwnerFromAuth(apiKey('the-key'));
+      expect(authMatchesSessionOwner(apiKey('the-key'), owner)).toBe(true);
+    });
+
+    it('rejects an api-key request with a different key', () => {
+      const owner = sessionOwnerFromAuth(apiKey('victim-key'));
+      expect(authMatchesSessionOwner(apiKey('attacker-key'), owner)).toBe(false);
+    });
+
+    it('rejects a bearer request against an api-key session', () => {
+      const owner = sessionOwnerFromAuth(apiKey('the-key'));
+      expect(authMatchesSessionOwner(bearer('jwt'), owner)).toBe(false);
     });
   });
 });

--- a/upsun-mcp/test/core/gateway.test.ts
+++ b/upsun-mcp/test/core/gateway.test.ts
@@ -24,7 +24,6 @@ describe('LocalServer', () => {
     mockAdapterFactory = jest.fn().mockImplementation(() => ({
       connectWithApiKey: jest.fn().mockResolvedValue(undefined),
       connectWithBearer: jest.fn().mockResolvedValue(undefined),
-      setCurrentBearerToken: jest.fn(),
     })) as any;
   });
 
@@ -71,7 +70,6 @@ describe('GatewayServer', () => {
     mockAdapterFactory = jest.fn().mockImplementation(() => ({
       connectWithApiKey: jest.fn().mockResolvedValue(undefined),
       connectWithBearer: jest.fn().mockResolvedValue(undefined),
-      setCurrentBearerToken: jest.fn(),
     })) as any;
 
     // Create server instance

--- a/upsun-mcp/test/core/transport/http.test.ts
+++ b/upsun-mcp/test/core/transport/http.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { GatewayServer } from '../../../src/core/gateway';
 import { HttpTransport } from '../../../src/core/transport/http';
-import { API_KEY_CLIENT_ID } from '../../../src/core/authentication';
+import { API_KEY_CLIENT_ID, sessionOwnerFromAuth } from '../../../src/core/authentication';
 
 describe('HttpTransport', () => {
   let gateway: GatewayServer<any>;
@@ -36,6 +36,7 @@ describe('HttpTransport', () => {
     httpTransport.streamable['sess2'] = {
       transport: { handleRequest },
       server: { setCurrentBearerToken },
+      owner: { authType: 'bearer' },
     } as any;
     const req = {
       headers: { 'mcp-session-id': 'sess2' },
@@ -48,20 +49,95 @@ describe('HttpTransport', () => {
     expect(handleRequest).toHaveBeenCalled();
   });
 
-  it('should not call setCurrentBearerToken for API key auth on existing session', async () => {
+  it('should rebind the bearer token on every reuse so refreshed tokens take effect', async () => {
+    const setCurrentBearerToken = jest.fn();
+    const handleRequest = jest.fn();
+    httpTransport.streamable['sess2b'] = {
+      transport: { handleRequest },
+      server: { setCurrentBearerToken },
+      owner: { authType: 'bearer' },
+    } as any;
+    const req = {
+      headers: { 'mcp-session-id': 'sess2b' },
+      body: {},
+      auth: { token: 'refreshed-token', clientId: 'user-1', scopes: [] },
+    } as any;
+    await httpTransport.postSessionRequest(req, { headers: {} } as any);
+    expect(setCurrentBearerToken).toHaveBeenCalledWith('refreshed-token');
+  });
+
+  it('should reject reuse of a bearer session when an API key header is presented', async () => {
     const setCurrentBearerToken = jest.fn();
     const handleRequest = jest.fn();
     httpTransport.streamable['sess3'] = {
       transport: { handleRequest },
       server: { setCurrentBearerToken },
+      owner: { authType: 'bearer' },
     } as any;
     const req = {
       headers: { 'mcp-session-id': 'sess3' },
       body: {},
-      auth: { token: 'my-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
-    const res = {} as any;
+    const setHeader = jest.fn().mockReturnThis();
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      set: setHeader,
+      json: jest.fn(),
+    } as any;
     await httpTransport.postSessionRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(setCurrentBearerToken).not.toHaveBeenCalled();
+    expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it('should reject reuse of an API-key session presented with a different key', async () => {
+    const handleRequest = jest.fn();
+    const owner = sessionOwnerFromAuth({
+      token: 'victim-key',
+      clientId: API_KEY_CLIENT_ID,
+      scopes: [],
+    } as any);
+    httpTransport.streamable['sess4'] = {
+      transport: { handleRequest },
+      server: { setCurrentBearerToken: jest.fn() },
+      owner,
+    } as any;
+    const req = {
+      headers: { 'mcp-session-id': 'sess4' },
+      body: {},
+      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+    } as any;
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as any;
+    await httpTransport.postSessionRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it('should allow reuse of an API-key session presented with the same key', async () => {
+    const handleRequest = jest.fn();
+    const setCurrentBearerToken = jest.fn();
+    const owner = sessionOwnerFromAuth({
+      token: 'same-key',
+      clientId: API_KEY_CLIENT_ID,
+      scopes: [],
+    } as any);
+    httpTransport.streamable['sess5'] = {
+      transport: { handleRequest },
+      server: { setCurrentBearerToken },
+      owner,
+    } as any;
+    const req = {
+      headers: { 'mcp-session-id': 'sess5' },
+      body: {},
+      auth: { token: 'same-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+    } as any;
+    await httpTransport.postSessionRequest(req, { headers: {} } as any);
+    // API-key sessions are already bound to the key, so no bearer rebind occurs.
     expect(setCurrentBearerToken).not.toHaveBeenCalled();
     expect(handleRequest).toHaveBeenCalled();
   });
@@ -180,25 +256,54 @@ describe('HttpTransport', () => {
   });
 
   it('should call handleSessionRequest and return 400 if sessionId missing', async () => {
-    const req = { headers: {} } as any;
+    const req = { headers: {}, auth: { token: 'tok', clientId: 'user-1', scopes: [] } } as any;
     const res = { status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
     await httpTransport.handleSessionRequest(req, res);
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.send).toHaveBeenCalledWith('Invalid or missing session ID');
   });
 
-  it('should handle handleSessionRequest with valid sessionId', async () => {
+  it('should handle handleSessionRequest with valid sessionId owned by the requester', async () => {
     const handleRequest = jest.fn(async () => {});
     httpTransport.streamable['valid-sess'] = {
       transport: { handleRequest },
       server: { setCurrentBearerToken: jest.fn() },
+      owner: { authType: 'bearer' },
     } as any;
 
-    const req = { headers: { 'mcp-session-id': 'valid-sess' }, body: {} } as any;
+    const req = {
+      headers: { 'mcp-session-id': 'valid-sess' },
+      body: {},
+      auth: { token: 'tok', clientId: 'user-1', scopes: [] },
+    } as any;
     const res = {} as any;
 
     await httpTransport.handleSessionRequest(req, res);
     expect(handleRequest).toHaveBeenCalled();
+  });
+
+  it('should reject handleSessionRequest from a non-owning principal', async () => {
+    const handleRequest = jest.fn(async () => {});
+    httpTransport.streamable['owned-sess'] = {
+      transport: { handleRequest },
+      server: { setCurrentBearerToken: jest.fn() },
+      owner: { authType: 'bearer' },
+    } as any;
+
+    const req = {
+      headers: { 'mcp-session-id': 'owned-sess' },
+      body: {},
+      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+    } as any;
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as any;
+
+    await httpTransport.handleSessionRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(handleRequest).not.toHaveBeenCalled();
   });
 
   it('should call closeAllSessions and clear streamable', async () => {

--- a/upsun-mcp/test/core/transport/http.test.ts
+++ b/upsun-mcp/test/core/transport/http.test.ts
@@ -30,13 +30,13 @@ describe('HttpTransport', () => {
     expect(typeof httpTransport.postSessionRequest).toBe('function');
   });
 
-  it('should call setCurrentBearerToken and handleRequest if sessionId and bearer auth', async () => {
-    const setCurrentBearerToken = jest.fn();
+  it('should dispatch to the session when the same token is presented', async () => {
     const handleRequest = jest.fn();
+    const owner = sessionOwnerFromAuth({ token: 'token', clientId: 'user-1', scopes: [] } as any);
     httpTransport.streamable['sess2'] = {
       transport: { handleRequest },
-      server: { setCurrentBearerToken },
-      owner: { authType: 'bearer' },
+      server: {},
+      owner,
     } as any;
     const req = {
       headers: { 'mcp-session-id': 'sess2' },
@@ -45,101 +45,41 @@ describe('HttpTransport', () => {
     } as any;
     const res = {} as any;
     await httpTransport.postSessionRequest(req, res);
-    expect(setCurrentBearerToken).toHaveBeenCalledWith('token');
     expect(handleRequest).toHaveBeenCalled();
   });
 
-  it('should rebind the bearer token on every reuse so refreshed tokens take effect', async () => {
-    const setCurrentBearerToken = jest.fn();
+  it('should reject reuse with a different token as 404 Session not found', async () => {
     const handleRequest = jest.fn();
-    httpTransport.streamable['sess2b'] = {
-      transport: { handleRequest },
-      server: { setCurrentBearerToken },
-      owner: { authType: 'bearer' },
-    } as any;
-    const req = {
-      headers: { 'mcp-session-id': 'sess2b' },
-      body: {},
-      auth: { token: 'refreshed-token', clientId: 'user-1', scopes: [] },
-    } as any;
-    await httpTransport.postSessionRequest(req, { headers: {} } as any);
-    expect(setCurrentBearerToken).toHaveBeenCalledWith('refreshed-token');
-  });
-
-  it('should reject reuse of a bearer session when an API key header is presented', async () => {
-    const setCurrentBearerToken = jest.fn();
-    const handleRequest = jest.fn();
+    const owner = sessionOwnerFromAuth({
+      token: 'victim-token',
+      clientId: 'user-1',
+      scopes: [],
+    } as any);
     httpTransport.streamable['sess3'] = {
       transport: { handleRequest },
-      server: { setCurrentBearerToken },
-      owner: { authType: 'bearer' },
+      server: {},
+      owner,
     } as any;
     const req = {
       headers: { 'mcp-session-id': 'sess3' },
       body: {},
-      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: { token: 'attacker-token', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
-    const setHeader = jest.fn().mockReturnThis();
-    const res = {
-      status: jest.fn().mockReturnThis(),
-      set: setHeader,
-      json: jest.fn(),
-    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(setCurrentBearerToken).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
     expect(handleRequest).not.toHaveBeenCalled();
   });
 
-  it('should reject reuse of an API-key session presented with a different key', async () => {
-    const handleRequest = jest.fn();
-    const owner = sessionOwnerFromAuth({
-      token: 'victim-key',
-      clientId: API_KEY_CLIENT_ID,
-      scopes: [],
-    } as any);
-    httpTransport.streamable['sess4'] = {
-      transport: { handleRequest },
-      server: { setCurrentBearerToken: jest.fn() },
-      owner,
-    } as any;
+  it('should reject an unknown session id as 404, indistinguishable from a wrong token', async () => {
     const req = {
-      headers: { 'mcp-session-id': 'sess4' },
+      headers: { 'mcp-session-id': 'does-not-exist' },
       body: {},
-      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: { token: 'token', clientId: 'user-1', scopes: [] },
     } as any;
-    const res = {
-      status: jest.fn().mockReturnThis(),
-      set: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(handleRequest).not.toHaveBeenCalled();
-  });
-
-  it('should allow reuse of an API-key session presented with the same key', async () => {
-    const handleRequest = jest.fn();
-    const setCurrentBearerToken = jest.fn();
-    const owner = sessionOwnerFromAuth({
-      token: 'same-key',
-      clientId: API_KEY_CLIENT_ID,
-      scopes: [],
-    } as any);
-    httpTransport.streamable['sess5'] = {
-      transport: { handleRequest },
-      server: { setCurrentBearerToken },
-      owner,
-    } as any;
-    const req = {
-      headers: { 'mcp-session-id': 'sess5' },
-      body: {},
-      auth: { token: 'same-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
-    } as any;
-    await httpTransport.postSessionRequest(req, { headers: {} } as any);
-    // API-key sessions are already bound to the key, so no bearer rebind occurs.
-    expect(setCurrentBearerToken).not.toHaveBeenCalled();
-    expect(handleRequest).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
   });
 
   it('should create transport with enableJsonResponse: true on init', async () => {
@@ -148,7 +88,6 @@ describe('HttpTransport', () => {
     const fakeAdapter = {
       connectWithApiKey,
       connectWithBearer: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),
@@ -187,7 +126,6 @@ describe('HttpTransport', () => {
     const fakeAdapter = {
       connectWithBearer,
       connectWithApiKey: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),
@@ -217,7 +155,6 @@ describe('HttpTransport', () => {
     const fakeAdapter = {
       connectWithApiKey,
       connectWithBearer: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),
@@ -263,12 +200,13 @@ describe('HttpTransport', () => {
     expect(res.send).toHaveBeenCalledWith('Invalid or missing session ID');
   });
 
-  it('should handle handleSessionRequest with valid sessionId owned by the requester', async () => {
+  it('should handle handleSessionRequest with valid sessionId and matching token', async () => {
     const handleRequest = jest.fn(async () => {});
+    const owner = sessionOwnerFromAuth({ token: 'tok', clientId: 'user-1', scopes: [] } as any);
     httpTransport.streamable['valid-sess'] = {
       transport: { handleRequest },
-      server: { setCurrentBearerToken: jest.fn() },
-      owner: { authType: 'bearer' },
+      server: {},
+      owner,
     } as any;
 
     const req = {
@@ -282,27 +220,28 @@ describe('HttpTransport', () => {
     expect(handleRequest).toHaveBeenCalled();
   });
 
-  it('should reject handleSessionRequest from a non-owning principal', async () => {
+  it('should reject handleSessionRequest presenting a different token as 404', async () => {
     const handleRequest = jest.fn(async () => {});
+    const owner = sessionOwnerFromAuth({
+      token: 'owner-tok',
+      clientId: 'user-1',
+      scopes: [],
+    } as any);
     httpTransport.streamable['owned-sess'] = {
       transport: { handleRequest },
-      server: { setCurrentBearerToken: jest.fn() },
-      owner: { authType: 'bearer' },
+      server: {},
+      owner,
     } as any;
 
     const req = {
       headers: { 'mcp-session-id': 'owned-sess' },
       body: {},
-      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: { token: 'attacker-token', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
-    const res = {
-      status: jest.fn().mockReturnThis(),
-      set: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
 
     await httpTransport.handleSessionRequest(req, res);
-    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.status).toHaveBeenCalledWith(404);
     expect(handleRequest).not.toHaveBeenCalled();
   });
 
@@ -320,5 +259,39 @@ describe('HttpTransport', () => {
     await httpTransport.closeAllSessions();
     await Promise.resolve();
     expect(httpTransport.streamable['err']).toBeUndefined();
+  });
+
+  it('should close a session when its token expiry is reached', async () => {
+    jest.useFakeTimers();
+    try {
+      const close = jest.fn(async () => {});
+      httpTransport.streamable['exp-sess'] = {
+        transport: { close },
+        server: {},
+        owner: 'deadbeef',
+      } as any;
+      const expiresAt = Math.floor(Date.now() / 1000) + 60;
+      (httpTransport as any).scheduleExpiry('exp-sess', expiresAt);
+
+      // Still present before the token expires.
+      jest.advanceTimersByTime(59_000);
+      expect(close).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      expect(close).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should not schedule expiry for tokens without an expiry (e.g. API keys)', () => {
+    httpTransport.streamable['no-exp'] = {
+      transport: { close: jest.fn() },
+      server: {},
+      owner: 'deadbeef',
+    } as any;
+    (httpTransport as any).scheduleExpiry('no-exp', undefined);
+    expect(httpTransport.streamable['no-exp'].expiryTimer).toBeUndefined();
   });
 });

--- a/upsun-mcp/test/core/transport/sse.test.ts
+++ b/upsun-mcp/test/core/transport/sse.test.ts
@@ -29,13 +29,13 @@ describe('SseTransport', () => {
     expect(typeof sseTransport.postSessionRequest).toBe('function');
   });
 
-  it('should call setCurrentBearerToken and handlePostMessage if sessionId and bearer', async () => {
-    const setCurrentBearerToken = jest.fn();
+  it('should dispatch the message when the same token is presented', async () => {
     const handlePostMessage = jest.fn();
+    const owner = sessionOwnerFromAuth({ token: 'token', clientId: 'user-1', scopes: [] } as any);
     sseTransport.sse['sess2'] = {
       transport: { handlePostMessage, sessionId: 'sess2' },
-      server: { setCurrentBearerToken },
-      owner: { authType: 'bearer' },
+      server: {},
+      owner,
     } as any;
     const req = {
       query: { sessionId: 'sess2' },
@@ -45,70 +45,43 @@ describe('SseTransport', () => {
     } as any;
     const res = {} as any;
     await sseTransport.postSessionRequest(req, res);
-    expect(setCurrentBearerToken).toHaveBeenCalledWith('token');
     expect(handlePostMessage).toHaveBeenCalled();
   });
 
-  it('should not call setCurrentBearerToken for API key auth', async () => {
-    const setCurrentBearerToken = jest.fn();
+  it('should reject a message with a different token as 404', async () => {
     const handlePostMessage = jest.fn();
-    sseTransport.sse['sess3'] = {
-      transport: { handlePostMessage, sessionId: 'sess3' },
-      server: { setCurrentBearerToken },
-      owner: sessionOwnerFromAuth({
-        token: 'my-key',
-        clientId: API_KEY_CLIENT_ID,
-        scopes: [],
-      } as any),
-    } as any;
-    const req = {
-      query: { sessionId: 'sess3' },
-      headers: {},
-      ip: '127.0.0.1',
-      auth: { token: 'my-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
-    } as any;
-    const res = {} as any;
-    await sseTransport.postSessionRequest(req, res);
-    expect(setCurrentBearerToken).not.toHaveBeenCalled();
-    expect(handlePostMessage).toHaveBeenCalled();
-  });
-
-  it('should reject reuse of a bearer session when an API key header is presented', async () => {
-    const setCurrentBearerToken = jest.fn();
-    const handlePostMessage = jest.fn();
+    const owner = sessionOwnerFromAuth({
+      token: 'owner-token',
+      clientId: 'user-1',
+      scopes: [],
+    } as any);
     sseTransport.sse['sess-cross'] = {
       transport: { handlePostMessage, sessionId: 'sess-cross' },
-      server: { setCurrentBearerToken },
-      owner: { authType: 'bearer' },
+      server: {},
+      owner,
     } as any;
     const req = {
       query: { sessionId: 'sess-cross' },
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: { token: 'attacker-token', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
-    const res = {
-      status: jest.fn().mockReturnThis(),
-      set: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await sseTransport.postSessionRequest(req, res);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(setCurrentBearerToken).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
     expect(handlePostMessage).not.toHaveBeenCalled();
   });
 
-  it('should return 400 if postSessionRequest called with unknown sessionId', async () => {
+  it('should return 404 if postSessionRequest called with unknown sessionId', async () => {
     const req = {
       query: { sessionId: 'notfound' },
       headers: {},
       ip: '127.0.0.1',
       auth: { token: 'tok', clientId: 'user-1', scopes: [] },
     } as any;
-    const res = { status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await sseTransport.postSessionRequest(req, res);
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.send).toHaveBeenCalledWith('No transport found for sessionId');
+    expect(res.status).toHaveBeenCalledWith(404);
   });
 
   it('should handle successful SSE connection creation with bearer', async () => {
@@ -116,7 +89,6 @@ describe('SseTransport', () => {
     const fakeAdapter = {
       connectWithBearer,
       connectWithApiKey: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),
@@ -146,7 +118,6 @@ describe('SseTransport', () => {
     const fakeAdapter = {
       connectWithApiKey,
       connectWithBearer: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),
@@ -175,7 +146,6 @@ describe('SseTransport', () => {
     const fakeAdapter = {
       connectWithBearer,
       connectWithApiKey: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),
@@ -202,7 +172,6 @@ describe('SseTransport', () => {
     const fakeAdapter = {
       connectWithBearer,
       connectWithApiKey: jest.fn(),
-      setCurrentBearerToken: jest.fn(),
       server: {},
       client: {},
       isMode: jest.fn(),

--- a/upsun-mcp/test/core/transport/sse.test.ts
+++ b/upsun-mcp/test/core/transport/sse.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { GatewayServer } from '../../../src/core/gateway';
 import { SseTransport } from '../../../src/core/transport/sse';
-import { API_KEY_CLIENT_ID } from '../../../src/core/authentication';
+import { API_KEY_CLIENT_ID, sessionOwnerFromAuth } from '../../../src/core/authentication';
 
 describe('SseTransport', () => {
   let gateway: GatewayServer<any>;
@@ -35,6 +35,7 @@ describe('SseTransport', () => {
     sseTransport.sse['sess2'] = {
       transport: { handlePostMessage, sessionId: 'sess2' },
       server: { setCurrentBearerToken },
+      owner: { authType: 'bearer' },
     } as any;
     const req = {
       query: { sessionId: 'sess2' },
@@ -54,6 +55,11 @@ describe('SseTransport', () => {
     sseTransport.sse['sess3'] = {
       transport: { handlePostMessage, sessionId: 'sess3' },
       server: { setCurrentBearerToken },
+      owner: sessionOwnerFromAuth({
+        token: 'my-key',
+        clientId: API_KEY_CLIENT_ID,
+        scopes: [],
+      } as any),
     } as any;
     const req = {
       query: { sessionId: 'sess3' },
@@ -65,6 +71,31 @@ describe('SseTransport', () => {
     await sseTransport.postSessionRequest(req, res);
     expect(setCurrentBearerToken).not.toHaveBeenCalled();
     expect(handlePostMessage).toHaveBeenCalled();
+  });
+
+  it('should reject reuse of a bearer session when an API key header is presented', async () => {
+    const setCurrentBearerToken = jest.fn();
+    const handlePostMessage = jest.fn();
+    sseTransport.sse['sess-cross'] = {
+      transport: { handlePostMessage, sessionId: 'sess-cross' },
+      server: { setCurrentBearerToken },
+      owner: { authType: 'bearer' },
+    } as any;
+    const req = {
+      query: { sessionId: 'sess-cross' },
+      headers: {},
+      ip: '127.0.0.1',
+      auth: { token: 'attacker-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+    } as any;
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as any;
+    await sseTransport.postSessionRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(setCurrentBearerToken).not.toHaveBeenCalled();
+    expect(handlePostMessage).not.toHaveBeenCalled();
   });
 
   it('should return 400 if postSessionRequest called with unknown sessionId', async () => {

--- a/upsun-mcp/test/mcpUpsun.test.ts
+++ b/upsun-mcp/test/mcpUpsun.test.ts
@@ -144,7 +144,6 @@ describe('UpsunMcpServer', () => {
     it('should have the required methods', () => {
       expect(typeof server.connectWithApiKey).toBe('function');
       expect(typeof server.connectWithBearer).toBe('function');
-      expect(typeof server.setCurrentBearerToken).toBe('function');
     });
 
     it('should have a server property', () => {
@@ -172,21 +171,6 @@ describe('UpsunMcpServer', () => {
 
       expect(server.client).toBeDefined();
       expect(server.server.connect).toHaveBeenCalledWith(mockTransport);
-    });
-  });
-
-  describe('client management', () => {
-    it('should set current bearer token on both adapter and client', async () => {
-      // Initialize the client first.
-      const mockTransport = { start: jest.fn() } as any;
-      await server.connectWithBearer(mockTransport, 'initial-token');
-
-      const spy = jest.spyOn(server.client, 'setBearerToken');
-      const token = 'test-bearer-token-456';
-      server.setCurrentBearerToken(token);
-
-      expect(server.currentBearerToken).toBe(token);
-      expect(spy).toHaveBeenCalledWith(token);
     });
   });
 


### PR DESCRIPTION
## Summary

MCP sessions were keyed only by `mcp-session-id`, and the streamable and SSE reuse paths skipped credential rebinding for API-key requests. As a result, a request that presented a known session id together with an `upsun-api-token` header reused an existing session while the upstream Upsun API call still used the credential bound when the session was created.

This change binds each session to the exact credential token that created it and enforces that binding on every reuse.

## How it works

- A session stores a SHA-256 hash of the token (OAuth bearer JWT or API key) that created it (`sessionOwnerFromAuth`).
- Every request reusing an `mcp-session-id` must present a token with the same hash (`authMatchesSessionOwner`, constant-time compared).
- Binding to the token rather than to a claim means the guarantee holds without verifying the JWT signature: a leaked `mcp-session-id` is useless without the token, and anyone holding the token already has the access the session would grant.
- No per-request credential rebind happens anymore — reuse only succeeds for the same token, which the session's client already holds. The unused `setCurrentBearerToken`/`currentBearerToken` are removed from the adapter.
- A request whose token does not match — including an unknown session id — receives `404 Session not found`. The two cases are indistinguishable, so the id cannot be used to probe for live sessions. A compliant MCP client responds by starting a new session, which is also how an OAuth access token refresh is handled (the new token no longer matches the old session).
- Because a bearer session cannot outlive its token, HTTP sessions are evicted at the token's `exp` so refreshed-out sessions do not accumulate; API keys carry no expiry and their sessions live until the transport closes.

This applies to the HTTP `POST`/`GET`/`DELETE` handlers and the SSE message handler.

## Verification

- `npm run build`, `npm run lint`, `npm run prettier:check` clean.
- Full suite passes (473 tests), coverage threshold met.
- Tests cover: reuse with the same token dispatches; reuse with a different token and an unknown session id both return 404; `GET`/`DELETE` token enforcement; token-hash does not leak the token; and session eviction at token expiry.

## Follow-up (tracked separately)

- Verifying JWT signatures locally would let the server reject forged/invalid bearer tokens at the edge. This is defense-in-depth only; it is not required for the session binding above, which does not rely on trusting token claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)