### PR TITLE
fix: use stateless streamable HTTP for OAuth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,21 +129,21 @@ upsun-mcp/
 1. **API Key**: Direct authentication via `upsun-api-token` header
 2. **Bearer Token**: Alternative authentication via `Authorization: Bearer` header
 3. **Write Control**: Write operations controlled via `enable-write` header
-4. **Session token binding**: Each session is bound to the exact credential token that
-   created it. The session stores a SHA-256 hash of that token (`sessionOwnerFromAuth`
-   in `core/authentication.ts`), and every request that reuses an existing
-   `mcp-session-id` must present a token with the same hash (`authMatchesSessionOwner`,
-   constant-time compared). Because the binding is to the token rather than to a claim,
-   it holds without verifying the JWT signature: a leaked `mcp-session-id` is useless
-   without the token, and anyone holding the token already has the access the session
-   would grant. A request whose token does not match — including an unknown session id —
-   receives `404 Session not found` (the two are indistinguishable, so the id cannot be
-   used to probe for live sessions); a compliant client responds by starting a new
-   session, which also covers the case of an OAuth access token having been refreshed.
-   This applies to the HTTP POST/GET/DELETE handlers and the SSE message handler. Because
-   a bearer session cannot outlive its token, HTTP sessions are evicted at the token's
-   `exp` so that refreshed-out sessions do not accumulate; API keys carry no expiry and
-   their sessions live until the transport closes.
+4. **Session token binding**: Stateful sessions are bound to the exact credential token
+   that created them. The session stores a SHA-256 hash of that token
+   (`sessionOwnerFromAuth` in `core/authentication.ts`), and every request that reuses an
+   existing `mcp-session-id` must present a token with the same hash
+   (`authMatchesSessionOwner`, constant-time compared). Because the binding is to the
+   token rather than to a claim, it holds without verifying the JWT signature: a leaked
+   `mcp-session-id` is useless without the token, and anyone holding the token already has
+   the access the session would grant. A request whose token does not match — including an
+   unknown session id — receives `404 Session not found` (the two are indistinguishable,
+   so the id cannot be used to probe for live sessions). Streamable HTTP bearer requests
+   are stateless and use a fresh transport for each POST, so refreshed OAuth access tokens
+   do not depend on client-side 404 session reinitialization. Bearer GET/DELETE requests
+   return `405` with `Allow: POST` because there is no stateful session or standalone SSE
+   stream to attach to. Exact-token session binding still applies to API-key Streamable
+   HTTP sessions and legacy SSE sessions.
 5. **Upstream 401 forwarding**: When the Upsun API returns 401 (expired/revoked token),
    the HTTP transport forwards the 401 status and `WWW-Authenticate` header directly to
    the MCP client so it can trigger OAuth2 token refresh. This only works on the

--- a/upsun-mcp/src/core/authentication.ts
+++ b/upsun-mcp/src/core/authentication.ts
@@ -13,6 +13,14 @@ export { WritableMode, HeaderKey, API_KEY_CLIENT_ID } from './types.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 export type { AuthInfo };
 
+export const AuthType = {
+  ApiKey: 'api-key',
+  Bearer: 'bearer',
+} as const;
+
+export type AuthType = (typeof AuthType)[keyof typeof AuthType];
+export type McpAuthInfo = AuthInfo & { authType: AuthType };
+
 // Create logger instance
 const log = createLogger('Auth');
 
@@ -193,7 +201,12 @@ export function requireMcpAuth(
     const raw = req.headers[HeaderKey.API_KEY];
     const apiKey = typeof raw === 'string' ? raw : undefined;
     if (apiKey && !isUnsubstitutedPlaceholder(apiKey)) {
-      req.auth = { token: apiKey, clientId: API_KEY_CLIENT_ID, scopes: [] };
+      req.auth = {
+        token: apiKey,
+        clientId: API_KEY_CLIENT_ID,
+        scopes: [],
+        authType: AuthType.ApiKey,
+      } as McpAuthInfo;
       return next();
     }
     if (apiKey && isUnsubstitutedPlaceholder(apiKey)) {
@@ -201,8 +214,20 @@ export function requireMcpAuth(
         `Ignoring ${HeaderKey.API_KEY} header with unsubstituted placeholder value; falling back to bearer auth`
       );
     }
-    bearerAuth(req, res, next);
+    bearerAuth(req, res, error => {
+      if (error) {
+        return next(error);
+      }
+      if (req.auth) {
+        req.auth = { ...req.auth, authType: AuthType.Bearer } as McpAuthInfo;
+      }
+      return next();
+    });
   };
+}
+
+export function isApiKeyAuth(auth: AuthInfo): auth is McpAuthInfo {
+  return (auth as Partial<McpAuthInfo>).authType === AuthType.ApiKey;
 }
 
 /**

--- a/upsun-mcp/src/core/authentication.ts
+++ b/upsun-mcp/src/core/authentication.ts
@@ -207,14 +207,16 @@ export function requireMcpAuth(
 
 /**
  * Identity of the principal that created an MCP session: a hex SHA-256 of the
- * credential token presented at creation (an OAuth bearer JWT or an API key).
+ * credential token presented at creation.
  *
  * A session is bound to the exact token that created it. Binding to the token
  * rather than to a claim means the guarantee holds without verifying the JWT
  * signature: someone who learns a session id cannot drive the session without
- * also presenting the same token, and anyone holding that token already has the
- * access the session would grant. When an OAuth token is refreshed the new
- * token no longer matches, so the client transparently starts a new session.
+ * also presenting the same token, and anyone holding that token already has
+ * the access the session would grant.
+ *
+ * Streamable HTTP bearer requests are stateless, so this exact-token binding
+ * applies to API-key Streamable sessions and legacy SSE sessions.
  */
 export type SessionOwner = string;
 
@@ -243,9 +245,7 @@ export function authMatchesSessionOwner(auth: AuthInfo, owner: SessionOwner): bo
  * Sends the "session not found" response (HTTP 404) used when a request targets
  * a session that does not exist or whose binding token does not match. The two
  * cases are deliberately indistinguishable so a session id cannot be used to
- * probe for live sessions. A compliant MCP client responds by starting a new
- * session with a fresh `initialize` request, which covers the legitimate case
- * of an OAuth access token having been refreshed.
+ * probe for live sessions.
  */
 export function rejectSessionNotFound(res: express.Response): void {
   res.status(404).json({

--- a/upsun-mcp/src/core/gateway.ts
+++ b/upsun-mcp/src/core/gateway.ts
@@ -163,11 +163,13 @@ export class GatewayServer<A extends McpAdapter> {
    *
    * Endpoints configured:
    * - POST /mcp: Client-to-server communication and session initialization
-   * - GET /mcp: Server-to-client notifications via streaming
-   * - DELETE /mcp: Session termination
+   * - GET /mcp: Server-to-client notifications via streaming for stateful API-key sessions
+   * - DELETE /mcp: Session termination for stateful API-key sessions
    *
-   * Sessions are managed via the 'mcp-session-id' header, with automatic cleanup
-   * when connections are closed.
+   * API-key sessions are managed via the 'mcp-session-id' header, with automatic
+   * cleanup when connections are closed. Bearer-token requests use stateless
+   * Streamable HTTP because refreshed OAuth access tokens cannot safely reuse
+   * exact-token-bound server sessions before JWT verification is available.
    *
    * @private
    */

--- a/upsun-mcp/src/core/transport/http.ts
+++ b/upsun-mcp/src/core/transport/http.ts
@@ -12,7 +12,7 @@ import { createLogger } from '../logger.js';
 import {
   extractMode,
   HeaderKey,
-  API_KEY_CLIENT_ID,
+  isApiKeyAuth,
   sessionOwnerFromAuth,
   authMatchesSessionOwner,
   rejectSessionNotFound,
@@ -56,7 +56,7 @@ export class HttpTransport {
     }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
     const mode = extractMode(req);
-    const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
+    const isApiKey = isApiKeyAuth(auth);
 
     if (!isApiKey) {
       await this.handleStatelessBearerRequest(req, res, auth, mode);
@@ -208,7 +208,7 @@ export class HttpTransport {
       return;
     }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
-    if (auth.clientId !== API_KEY_CLIENT_ID) {
+    if (!isApiKeyAuth(auth)) {
       res
         .status(405)
         .set('Allow', 'POST')

--- a/upsun-mcp/src/core/transport/http.ts
+++ b/upsun-mcp/src/core/transport/http.ts
@@ -24,7 +24,7 @@ import { requestContext } from '../requestContext.js';
 const httpLog = createLogger('Web:HTTP');
 
 export class HttpTransport {
-  /** Active streamable HTTP server transports (protocol version 2025-03-26) */
+  /** Active API-key Streamable HTTP server transports (protocol version 2025-03-26). */
   readonly streamable = {} as Record<
     string,
     {
@@ -55,11 +55,18 @@ export class HttpTransport {
       return;
     }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
+    const mode = extractMode(req);
+    const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
+
+    if (!isApiKey) {
+      await this.handleStatelessBearerRequest(req, res, auth, mode);
+      return;
+    }
 
     if (sessionId) {
-      // The session is bound to the token that created it. A request that does
-      // not present that token is treated as if the session does not exist, so
-      // an unknown id and a wrong token are indistinguishable to the caller.
+      // API-key sessions are bound to the token that created them. A request
+      // that does not present that token is treated as if the session does not
+      // exist, so an unknown id and a wrong token are indistinguishable.
       const session = this.streamable[sessionId];
       if (!session || !authMatchesSessionOwner(auth, session.owner)) {
         httpLog.warn('Rejecting session reuse: unknown session id or non-matching token');
@@ -76,8 +83,6 @@ export class HttpTransport {
     if (isInitializeRequest(req.body)) {
       httpLog.info('New session initialization request');
 
-      const mode = extractMode(req);
-      const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
       const server = this.gateway.makeInstanceAdapterMcpServer(mode);
 
       // enableJsonResponse defers writing HTTP headers until the handler completes,
@@ -88,8 +93,7 @@ export class HttpTransport {
         enableJsonResponse: true,
         onsessioninitialized: (sessionId): void => {
           this.streamable[sessionId] = { transport, server, owner: sessionOwnerFromAuth(auth) };
-          // Bound to the creating token, the session cannot outlive it; evict at
-          // the token's expiry so refreshed-out sessions do not accumulate.
+          // Bound to the creating token, the session cannot outlive it.
           this.scheduleExpiry(sessionId, auth.expiresAt);
         },
       });
@@ -100,14 +104,8 @@ export class HttpTransport {
         }
       };
 
-      // Connect server using appropriate authentication method.
-      if (isApiKey) {
-        httpLog.info('API key found for initialization, creating new session');
-        await server.connectWithApiKey(transport, auth.token);
-      } else {
-        httpLog.info('Bearer token found for initialization, creating new session');
-        await server.connectWithBearer(transport, auth.token);
-      }
+      httpLog.info('API key found for initialization, creating new session');
+      await server.connectWithApiKey(transport, auth.token);
 
       await requestContext.run({ res }, () => transport.handleRequest(req, res, req.body));
       return;
@@ -123,9 +121,34 @@ export class HttpTransport {
     });
   }
 
+  private async handleStatelessBearerRequest(
+    req: express.Request,
+    res: express.Response,
+    auth: AuthInfo,
+    mode: ReturnType<typeof extractMode>
+  ): Promise<void> {
+    httpLog.info('Handling bearer request with stateless Streamable transport');
+
+    const server = this.gateway.makeInstanceAdapterMcpServer(mode);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    try {
+      await server.connectWithBearer(transport, auth.token);
+      await requestContext.run({ res }, () => transport.handleRequest(req, res, req.body));
+    } finally {
+      try {
+        await transport.close();
+      } catch (error) {
+        httpLog.error('Error closing stateless bearer transport:', error);
+      }
+    }
+  }
+
   /**
-   * Schedules eviction of a session when its credential token expires. API-key
-   * tokens carry no expiry, so those sessions live until the transport closes.
+   * Schedules eviction of a session when its credential token expires.
    */
   private scheduleExpiry(sessionId: string, expiresAt?: number): void {
     if (expiresAt === undefined) {
@@ -185,12 +208,27 @@ export class HttpTransport {
       return;
     }
     const sessionId = req.headers[HeaderKey.MCP_SESSION_ID] as string | undefined;
+    if (auth.clientId !== API_KEY_CLIENT_ID) {
+      res
+        .status(405)
+        .set('Allow', 'POST')
+        .json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Method not allowed for stateless bearer transport.',
+          },
+          id: null,
+        });
+      return;
+    }
+
     if (!sessionId) {
       res.status(400).send('Invalid or missing session ID');
       return;
     }
 
-    // Unknown id and non-matching token are treated alike (see postSessionRequest).
+    // Unknown id and non-matching API-key tokens are treated alike.
     const session = this.streamable[sessionId];
     if (!session || !authMatchesSessionOwner(auth, session.owner)) {
       httpLog.warn('Rejecting session request: unknown session id or non-matching token');

--- a/upsun-mcp/src/core/transport/sse.ts
+++ b/upsun-mcp/src/core/transport/sse.ts
@@ -5,7 +5,7 @@ import { GatewayServer } from '../gateway.js';
 import { createLogger } from '../logger.js';
 import {
   extractMode,
-  API_KEY_CLIENT_ID,
+  isApiKeyAuth,
   sessionOwnerFromAuth,
   authMatchesSessionOwner,
   rejectSessionNotFound,
@@ -85,7 +85,7 @@ export class SseTransport {
       return;
     }
     const mode = extractMode(req);
-    const isApiKey = auth.clientId === API_KEY_CLIENT_ID;
+    const isApiKey = isApiKeyAuth(auth);
 
     // Create SSE transport for legacy clients.
     const transport = new SSEServerTransport(HTTP_MSG_PATH, res);
@@ -103,6 +103,7 @@ export class SseTransport {
         this.sseConnections.delete(transport.sessionId);
       }
     }, KEEP_ALIVE_INTERVAL_MS);
+    intervalId.unref?.();
 
     this.sseConnections.set(transport.sessionId, { res, intervalId });
     sseLog.info(`Client connected: ${transport.sessionId}, starting keep-alive.`);

--- a/upsun-mcp/test/core/authentication.test.ts
+++ b/upsun-mcp/test/core/authentication.test.ts
@@ -10,6 +10,7 @@ import {
   JwtTokenVerifier,
   requireMcpAuth,
   API_KEY_CLIENT_ID,
+  AuthType,
   sessionOwnerFromAuth,
   authMatchesSessionOwner,
 } from '../../src/core/authentication';
@@ -209,7 +210,12 @@ describe('Authentication Module', () => {
       middleware(req, res, mockNext);
 
       expect(mockNext).toHaveBeenCalled();
-      expect(req.auth).toEqual({ token: 'my-key', clientId: API_KEY_CLIENT_ID, scopes: [] });
+      expect(req.auth).toEqual({
+        token: 'my-key',
+        clientId: API_KEY_CLIENT_ID,
+        scopes: [],
+        authType: AuthType.ApiKey,
+      });
     });
 
     it('should authenticate valid JWT bearer token and populate req.auth', async () => {
@@ -240,6 +246,7 @@ describe('Authentication Module', () => {
         clientId: 'user-42',
         scopes: ['offline_access'],
         expiresAt: 9999999999 - 30,
+        authType: AuthType.Bearer,
       });
     });
 

--- a/upsun-mcp/test/core/transport/http.test.ts
+++ b/upsun-mcp/test/core/transport/http.test.ts
@@ -7,6 +7,7 @@ describe('HttpTransport', () => {
   let gateway: GatewayServer<any>;
   let httpTransport: HttpTransport;
   let handleRequestSpy: jest.SpiedFunction<any> | undefined;
+  let closeSpy: jest.SpiedFunction<any> | undefined;
 
   beforeEach(() => {
     gateway = {
@@ -18,6 +19,8 @@ describe('HttpTransport', () => {
   afterEach(() => {
     handleRequestSpy?.mockRestore();
     handleRequestSpy = undefined;
+    closeSpy?.mockRestore();
+    closeSpy = undefined;
   });
 
   it('should initialize with an empty streamable object', () => {
@@ -30,9 +33,13 @@ describe('HttpTransport', () => {
     expect(typeof httpTransport.postSessionRequest).toBe('function');
   });
 
-  it('should dispatch to the session when the same token is presented', async () => {
+  it('should dispatch API key requests to the session when the same token is presented', async () => {
     const handleRequest = jest.fn();
-    const owner = sessionOwnerFromAuth({ token: 'token', clientId: 'user-1', scopes: [] } as any);
+    const owner = sessionOwnerFromAuth({
+      token: 'token',
+      clientId: API_KEY_CLIENT_ID,
+      scopes: [],
+    } as any);
     httpTransport.streamable['sess2'] = {
       transport: { handleRequest },
       server: {},
@@ -41,18 +48,18 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'sess2' },
       body: {},
-      auth: { token: 'token', clientId: 'user-1', scopes: [] },
+      auth: { token: 'token', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
     const res = {} as any;
     await httpTransport.postSessionRequest(req, res);
     expect(handleRequest).toHaveBeenCalled();
   });
 
-  it('should reject reuse with a different token as 404 Session not found', async () => {
+  it('should reject API key reuse with a different token as 404 Session not found', async () => {
     const handleRequest = jest.fn();
     const owner = sessionOwnerFromAuth({
       token: 'victim-token',
-      clientId: 'user-1',
+      clientId: API_KEY_CLIENT_ID,
       scopes: [],
     } as any);
     httpTransport.streamable['sess3'] = {
@@ -71,11 +78,11 @@ describe('HttpTransport', () => {
     expect(handleRequest).not.toHaveBeenCalled();
   });
 
-  it('should reject an unknown session id as 404, indistinguishable from a wrong token', async () => {
+  it('should reject an unknown API key session id as 404, indistinguishable from a wrong token', async () => {
     const req = {
       headers: { 'mcp-session-id': 'does-not-exist' },
       body: {},
-      auth: { token: 'token', clientId: 'user-1', scopes: [] },
+      auth: { token: 'token', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
@@ -121,7 +128,7 @@ describe('HttpTransport', () => {
     }
   });
 
-  it('should create a new session on init with bearer', async () => {
+  it('should handle bearer requests with a stateless transport', async () => {
     const connectWithBearer = jest.fn();
     const fakeAdapter = {
       connectWithBearer,
@@ -147,6 +154,83 @@ describe('HttpTransport', () => {
     expect(makeInstanceAdapterMcpServer).toHaveBeenCalled();
     expect(connectWithBearer).toHaveBeenCalledWith(expect.anything(), 'bearer-token');
     expect(handleRequest).toHaveBeenCalled();
+    expect(Object.keys(httpTransport.streamable)).toHaveLength(0);
+  });
+
+  it('should preserve bearer request errors when stateless transport cleanup fails', async () => {
+    const connectWithBearer = jest.fn();
+    const fakeAdapter = {
+      connectWithBearer,
+      connectWithApiKey: jest.fn(),
+      server: {},
+      client: {},
+      isMode: jest.fn(),
+    } as any;
+    const requestError = new Error('request failed');
+    const cleanupError = new Error('cleanup failed');
+
+    httpTransport.gateway.makeInstanceAdapterMcpServer = jest.fn(() => fakeAdapter);
+
+    const req = {
+      headers: {},
+      body: { jsonrpc: '2.0', method: 'tools/list', id: 2 },
+      auth: { token: 'bearer-token', clientId: 'user-1', scopes: [] },
+    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+
+    const mod = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
+    handleRequestSpy = jest
+      .spyOn(mod.StreamableHTTPServerTransport.prototype, 'handleRequest')
+      .mockRejectedValue(requestError);
+    closeSpy = jest
+      .spyOn(mod.StreamableHTTPServerTransport.prototype, 'close')
+      .mockRejectedValue(cleanupError);
+
+    await expect(httpTransport.postSessionRequest(req, res)).rejects.toThrow('request failed');
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('should ignore stale session IDs for bearer stateless requests', async () => {
+    const connectWithBearer = jest.fn();
+    const handleRequest = jest.fn(async () => {});
+    const fakeAdapter = {
+      connectWithBearer,
+      connectWithApiKey: jest.fn(),
+      server: {},
+      client: {},
+      isMode: jest.fn(),
+    } as any;
+
+    httpTransport.gateway.makeInstanceAdapterMcpServer = jest.fn(() => fakeAdapter);
+
+    const owner = sessionOwnerFromAuth({
+      token: 'old-bearer-token',
+      clientId: 'user-1',
+      scopes: [],
+    } as any);
+    httpTransport.streamable['stale-sess'] = {
+      transport: { handleRequest: jest.fn() },
+      server: {},
+      owner,
+    } as any;
+
+    const req = {
+      headers: { 'mcp-session-id': 'stale-sess' },
+      body: { jsonrpc: '2.0', method: 'tools/list', id: 2 },
+      auth: { token: 'refreshed-bearer-token', clientId: 'user-1', scopes: [] },
+    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+
+    const mod = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
+    handleRequestSpy = jest
+      .spyOn(mod.StreamableHTTPServerTransport.prototype, 'handleRequest')
+      .mockImplementation(handleRequest);
+
+    await httpTransport.postSessionRequest(req, res);
+
+    expect(connectWithBearer).toHaveBeenCalledWith(expect.anything(), 'refreshed-bearer-token');
+    expect(handleRequest).toHaveBeenCalledWith(req, res, req.body);
+    expect(res.status).not.toHaveBeenCalledWith(404);
   });
 
   it('should create a new session on init with API key', async () => {
@@ -180,11 +264,11 @@ describe('HttpTransport', () => {
     expect(handleRequest).toHaveBeenCalled();
   });
 
-  it('should return 400 if no sessionId and not an init request', async () => {
+  it('should return 400 for an API key request if no sessionId and not an init request', async () => {
     const req = {
       headers: {},
       body: {},
-      auth: { token: 'tok', clientId: 'user-1', scopes: [] },
+      auth: { token: 'tok', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
@@ -192,17 +276,43 @@ describe('HttpTransport', () => {
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.anything() }));
   });
 
-  it('should call handleSessionRequest and return 400 if sessionId missing', async () => {
-    const req = { headers: {}, auth: { token: 'tok', clientId: 'user-1', scopes: [] } } as any;
+  it('should call handleSessionRequest and return 400 if API key sessionId is missing', async () => {
+    const req = {
+      headers: {},
+      auth: { token: 'tok', clientId: API_KEY_CLIENT_ID, scopes: [] },
+    } as any;
     const res = { status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
     await httpTransport.handleSessionRequest(req, res);
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.send).toHaveBeenCalledWith('Invalid or missing session ID');
   });
 
-  it('should handle handleSessionRequest with valid sessionId and matching token', async () => {
+  it('should return 405 for bearer GET/DELETE streamable requests', async () => {
+    const req = { headers: {}, auth: { token: 'tok', clientId: 'user-1', scopes: [] } } as any;
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as any;
+    await httpTransport.handleSessionRequest(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.set).toHaveBeenCalledWith('Allow', 'POST');
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'Method not allowed for stateless bearer transport.',
+        }),
+      })
+    );
+  });
+
+  it('should handle handleSessionRequest with valid API key sessionId and matching token', async () => {
     const handleRequest = jest.fn(async () => {});
-    const owner = sessionOwnerFromAuth({ token: 'tok', clientId: 'user-1', scopes: [] } as any);
+    const owner = sessionOwnerFromAuth({
+      token: 'tok',
+      clientId: API_KEY_CLIENT_ID,
+      scopes: [],
+    } as any);
     httpTransport.streamable['valid-sess'] = {
       transport: { handleRequest },
       server: {},
@@ -212,7 +322,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'valid-sess' },
       body: {},
-      auth: { token: 'tok', clientId: 'user-1', scopes: [] },
+      auth: { token: 'tok', clientId: API_KEY_CLIENT_ID, scopes: [] },
     } as any;
     const res = {} as any;
 
@@ -220,11 +330,11 @@ describe('HttpTransport', () => {
     expect(handleRequest).toHaveBeenCalled();
   });
 
-  it('should reject handleSessionRequest presenting a different token as 404', async () => {
+  it('should reject handleSessionRequest presenting a different API key token as 404', async () => {
     const handleRequest = jest.fn(async () => {});
     const owner = sessionOwnerFromAuth({
       token: 'owner-tok',
-      clientId: 'user-1',
+      clientId: API_KEY_CLIENT_ID,
       scopes: [],
     } as any);
     httpTransport.streamable['owned-sess'] = {

--- a/upsun-mcp/test/core/transport/http.test.ts
+++ b/upsun-mcp/test/core/transport/http.test.ts
@@ -1,7 +1,25 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { GatewayServer } from '../../../src/core/gateway';
 import { HttpTransport } from '../../../src/core/transport/http';
-import { API_KEY_CLIENT_ID, sessionOwnerFromAuth } from '../../../src/core/authentication';
+import {
+  API_KEY_CLIENT_ID,
+  AuthType,
+  sessionOwnerFromAuth,
+} from '../../../src/core/authentication';
+
+const apiKeyAuth = (token: string) => ({
+  token,
+  clientId: API_KEY_CLIENT_ID,
+  scopes: [],
+  authType: AuthType.ApiKey,
+});
+
+const bearerAuth = (token: string, clientId = 'user-1') => ({
+  token,
+  clientId,
+  scopes: [],
+  authType: AuthType.Bearer,
+});
 
 describe('HttpTransport', () => {
   let gateway: GatewayServer<any>;
@@ -35,11 +53,7 @@ describe('HttpTransport', () => {
 
   it('should dispatch API key requests to the session when the same token is presented', async () => {
     const handleRequest = jest.fn();
-    const owner = sessionOwnerFromAuth({
-      token: 'token',
-      clientId: API_KEY_CLIENT_ID,
-      scopes: [],
-    } as any);
+    const owner = sessionOwnerFromAuth(apiKeyAuth('token'));
     httpTransport.streamable['sess2'] = {
       transport: { handleRequest },
       server: {},
@@ -48,7 +62,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'sess2' },
       body: {},
-      auth: { token: 'token', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('token'),
     } as any;
     const res = {} as any;
     await httpTransport.postSessionRequest(req, res);
@@ -57,11 +71,7 @@ describe('HttpTransport', () => {
 
   it('should reject API key reuse with a different token as 404 Session not found', async () => {
     const handleRequest = jest.fn();
-    const owner = sessionOwnerFromAuth({
-      token: 'victim-token',
-      clientId: API_KEY_CLIENT_ID,
-      scopes: [],
-    } as any);
+    const owner = sessionOwnerFromAuth(apiKeyAuth('victim-token'));
     httpTransport.streamable['sess3'] = {
       transport: { handleRequest },
       server: {},
@@ -70,7 +80,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'sess3' },
       body: {},
-      auth: { token: 'attacker-token', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('attacker-token'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
@@ -82,7 +92,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'does-not-exist' },
       body: {},
-      auth: { token: 'token', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('token'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
@@ -110,7 +120,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: {},
       body: { jsonrpc: '2.0', method: 'initialize', id: 1, params: {} },
-      auth: { token: 'test-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('test-key'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
 
@@ -143,7 +153,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: {},
       body: { jsonrpc: '2.0', method: 'initialize', id: 1, params: {} },
-      auth: { token: 'bearer-token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('bearer-token', API_KEY_CLIENT_ID),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     const mod = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
@@ -174,7 +184,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: {},
       body: { jsonrpc: '2.0', method: 'tools/list', id: 2 },
-      auth: { token: 'bearer-token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('bearer-token'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
 
@@ -203,11 +213,7 @@ describe('HttpTransport', () => {
 
     httpTransport.gateway.makeInstanceAdapterMcpServer = jest.fn(() => fakeAdapter);
 
-    const owner = sessionOwnerFromAuth({
-      token: 'old-bearer-token',
-      clientId: 'user-1',
-      scopes: [],
-    } as any);
+    const owner = sessionOwnerFromAuth(bearerAuth('old-bearer-token'));
     httpTransport.streamable['stale-sess'] = {
       transport: { handleRequest: jest.fn() },
       server: {},
@@ -217,7 +223,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'stale-sess' },
       body: { jsonrpc: '2.0', method: 'tools/list', id: 2 },
-      auth: { token: 'refreshed-bearer-token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('refreshed-bearer-token'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
 
@@ -249,7 +255,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: {},
       body: { jsonrpc: '2.0', method: 'initialize', id: 1, params: {} },
-      auth: { token: 'test-api-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('test-api-key'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
 
@@ -268,7 +274,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: {},
       body: {},
-      auth: { token: 'tok', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('tok'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await httpTransport.postSessionRequest(req, res);
@@ -279,7 +285,7 @@ describe('HttpTransport', () => {
   it('should call handleSessionRequest and return 400 if API key sessionId is missing', async () => {
     const req = {
       headers: {},
-      auth: { token: 'tok', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('tok'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
     await httpTransport.handleSessionRequest(req, res);
@@ -288,7 +294,10 @@ describe('HttpTransport', () => {
   });
 
   it('should return 405 for bearer GET/DELETE streamable requests', async () => {
-    const req = { headers: {}, auth: { token: 'tok', clientId: 'user-1', scopes: [] } } as any;
+    const req = {
+      headers: {},
+      auth: bearerAuth('tok', API_KEY_CLIENT_ID),
+    } as any;
     const res = {
       status: jest.fn().mockReturnThis(),
       set: jest.fn().mockReturnThis(),
@@ -308,11 +317,7 @@ describe('HttpTransport', () => {
 
   it('should handle handleSessionRequest with valid API key sessionId and matching token', async () => {
     const handleRequest = jest.fn(async () => {});
-    const owner = sessionOwnerFromAuth({
-      token: 'tok',
-      clientId: API_KEY_CLIENT_ID,
-      scopes: [],
-    } as any);
+    const owner = sessionOwnerFromAuth(apiKeyAuth('tok'));
     httpTransport.streamable['valid-sess'] = {
       transport: { handleRequest },
       server: {},
@@ -322,7 +327,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'valid-sess' },
       body: {},
-      auth: { token: 'tok', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('tok'),
     } as any;
     const res = {} as any;
 
@@ -332,11 +337,7 @@ describe('HttpTransport', () => {
 
   it('should reject handleSessionRequest presenting a different API key token as 404', async () => {
     const handleRequest = jest.fn(async () => {});
-    const owner = sessionOwnerFromAuth({
-      token: 'owner-tok',
-      clientId: API_KEY_CLIENT_ID,
-      scopes: [],
-    } as any);
+    const owner = sessionOwnerFromAuth(apiKeyAuth('owner-tok'));
     httpTransport.streamable['owned-sess'] = {
       transport: { handleRequest },
       server: {},
@@ -346,7 +347,7 @@ describe('HttpTransport', () => {
     const req = {
       headers: { 'mcp-session-id': 'owned-sess' },
       body: {},
-      auth: { token: 'attacker-token', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('attacker-token'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
 

--- a/upsun-mcp/test/core/transport/sse.test.ts
+++ b/upsun-mcp/test/core/transport/sse.test.ts
@@ -1,7 +1,25 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { GatewayServer } from '../../../src/core/gateway';
 import { SseTransport } from '../../../src/core/transport/sse';
-import { API_KEY_CLIENT_ID, sessionOwnerFromAuth } from '../../../src/core/authentication';
+import {
+  API_KEY_CLIENT_ID,
+  AuthType,
+  sessionOwnerFromAuth,
+} from '../../../src/core/authentication';
+
+const apiKeyAuth = (token: string) => ({
+  token,
+  clientId: API_KEY_CLIENT_ID,
+  scopes: [],
+  authType: AuthType.ApiKey,
+});
+
+const bearerAuth = (token: string, clientId = 'user-1') => ({
+  token,
+  clientId,
+  scopes: [],
+  authType: AuthType.Bearer,
+});
 
 describe('SseTransport', () => {
   let gateway: GatewayServer<any>;
@@ -31,7 +49,7 @@ describe('SseTransport', () => {
 
   it('should dispatch the message when the same token is presented', async () => {
     const handlePostMessage = jest.fn();
-    const owner = sessionOwnerFromAuth({ token: 'token', clientId: 'user-1', scopes: [] } as any);
+    const owner = sessionOwnerFromAuth(bearerAuth('token'));
     sseTransport.sse['sess2'] = {
       transport: { handlePostMessage, sessionId: 'sess2' },
       server: {},
@@ -41,7 +59,7 @@ describe('SseTransport', () => {
       query: { sessionId: 'sess2' },
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('token'),
     } as any;
     const res = {} as any;
     await sseTransport.postSessionRequest(req, res);
@@ -50,11 +68,7 @@ describe('SseTransport', () => {
 
   it('should reject a message with a different token as 404', async () => {
     const handlePostMessage = jest.fn();
-    const owner = sessionOwnerFromAuth({
-      token: 'owner-token',
-      clientId: 'user-1',
-      scopes: [],
-    } as any);
+    const owner = sessionOwnerFromAuth(bearerAuth('owner-token'));
     sseTransport.sse['sess-cross'] = {
       transport: { handlePostMessage, sessionId: 'sess-cross' },
       server: {},
@@ -64,7 +78,7 @@ describe('SseTransport', () => {
       query: { sessionId: 'sess-cross' },
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'attacker-token', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('attacker-token'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await sseTransport.postSessionRequest(req, res);
@@ -77,7 +91,7 @@ describe('SseTransport', () => {
       query: { sessionId: 'notfound' },
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'tok', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('tok'),
     } as any;
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
     await sseTransport.postSessionRequest(req, res);
@@ -99,7 +113,7 @@ describe('SseTransport', () => {
     const req = {
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'valid-token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('valid-token', API_KEY_CLIENT_ID),
     } as any;
     const res = {
       writableEnded: false,
@@ -128,7 +142,7 @@ describe('SseTransport', () => {
     const req = {
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'my-api-key', clientId: API_KEY_CLIENT_ID, scopes: [] },
+      auth: apiKeyAuth('my-api-key'),
     } as any;
     const res = {
       writableEnded: false,
@@ -154,7 +168,7 @@ describe('SseTransport', () => {
     const req = {
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('token'),
     } as any;
     const res = {
       writableEnded: false,
@@ -187,7 +201,7 @@ describe('SseTransport', () => {
     const req = {
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('token'),
     } as any;
     await sseTransport.getSessionRequest(req, res);
     expect(Object.keys(sseTransport.sse)).toHaveLength(0);
@@ -208,7 +222,7 @@ describe('SseTransport', () => {
     const req = {
       headers: {},
       ip: '127.0.0.1',
-      auth: { token: 'token', clientId: 'user-1', scopes: [] },
+      auth: bearerAuth('token'),
     } as any;
     const res = {
       writableEnded: false,


### PR DESCRIPTION
## Summary
- Use stateless Streamable HTTP for bearer-authenticated requests.
- Keep API-key Streamable HTTP sessions stateful and exact-token-bound.
- Update transport tests for bearer stateless handling and API-key session binding.

## Tests
- npm test -- --runTestsByPath test/core/transport/http.test.ts
- npm run build
- npm run lint

Generated by Codex.