### PR TITLE
feat(read-tools): strip HAL envelope from read output, full opt-out

### DIFF
--- a/upsun-mcp/src/command/activity.ts
+++ b/upsun-mcp/src/command/activity.ts
@@ -13,6 +13,7 @@ import { createLogger } from '../core/logger.js';
 // Create logger for activity operations
 const log = createLogger('MCP:Tool:activity-commands');
 import { Response, Schema, ToolWrapper } from '../core/helper.js';
+import { lean } from '../core/lean.js';
 
 /**
  * Registers activity management tools with the MCP server.
@@ -82,12 +83,13 @@ export function registerActivity(adapter: McpAdapter): void {
       inputSchema: {
         project_id: Schema.projectId(),
         activity_id: Schema.activityId(),
+        full: Schema.full(),
       },
     },
-    ToolWrapper.trace('get-activity', async ({ project_id, activity_id }) => {
+    ToolWrapper.trace('get-activity', async ({ project_id, activity_id, full }) => {
       log.debug(`Get Activity ${activity_id} in Project ${project_id}`);
       const result = await adapter.client.activities.get(project_id, activity_id);
-      return Response.json(result);
+      return Response.json(full ? result : lean(result));
     })
   );
 
@@ -108,12 +110,13 @@ export function registerActivity(adapter: McpAdapter): void {
       description: 'List all activities of upsun project',
       inputSchema: {
         project_id: Schema.projectId(),
+        full: Schema.full(),
       },
     },
-    ToolWrapper.trace('list-activity', async ({ project_id }) => {
+    ToolWrapper.trace('list-activity', async ({ project_id, full }) => {
       log.debug(`List Activities in Project ${project_id}`);
       const result = await adapter.client.activities.list(project_id);
-      return Response.json(result);
+      return Response.json(full ? result : lean(result));
     })
   );
 

--- a/upsun-mcp/src/command/environment.ts
+++ b/upsun-mcp/src/command/environment.ts
@@ -9,6 +9,7 @@
 
 import { McpAdapter } from '../core/adapter.js';
 import { Response, Schema, ToolWrapper } from '../core/helper.js';
+import { lean } from '../core/lean.js';
 import { createLogger } from '../core/logger.js';
 
 // Create logger for environment operations
@@ -115,13 +116,14 @@ export function registerEnvironment(adapter: McpAdapter): void {
       inputSchema: {
         project_id: Schema.projectId(),
         environment_name: Schema.environmentName(),
+        full: Schema.full(),
       },
     },
-    ToolWrapper.trace('info-environment', async ({ project_id, environment_name }) => {
+    ToolWrapper.trace('info-environment', async ({ project_id, environment_name, full }) => {
       log.debug(`Get Info of Environment ${environment_name} in Project ${project_id}`);
       const result = await adapter.client.environments.info(project_id, environment_name);
 
-      return Response.json(result);
+      return Response.json(full ? result : lean(result));
     })
   );
 
@@ -141,13 +143,14 @@ export function registerEnvironment(adapter: McpAdapter): void {
       description: 'List all environments of upsun project',
       inputSchema: {
         project_id: Schema.projectId(),
+        full: Schema.full(),
       },
     },
-    ToolWrapper.trace('list-environment', async ({ project_id }) => {
+    ToolWrapper.trace('list-environment', async ({ project_id, full }) => {
       log.debug(`List Environments in Project ${project_id}`);
       const result = await adapter.client.environments.list(project_id);
 
-      return Response.json(result);
+      return Response.json(full ? result : lean(result));
     })
   );
 
@@ -326,13 +329,14 @@ export function registerEnvironment(adapter: McpAdapter): void {
       inputSchema: {
         project_id: Schema.projectId(),
         environment_name: Schema.environmentName(),
+        full: Schema.full(),
       },
     },
-    ToolWrapper.trace('urls-environment', async ({ project_id, environment_name }) => {
+    ToolWrapper.trace('urls-environment', async ({ project_id, environment_name, full }) => {
       log.debug(`Get URLs of Environment ${environment_name} in Project ${project_id}`);
       const result = await adapter.client.routes.list(project_id, environment_name);
 
-      return Response.json(result);
+      return Response.json(full ? result : lean(result));
     })
   );
 }

--- a/upsun-mcp/src/command/project.ts
+++ b/upsun-mcp/src/command/project.ts
@@ -10,6 +10,7 @@ import { SubscriptionStatusEnum } from 'upsun-sdk-node/dist/model/index.js';
 import { z } from 'zod';
 import { McpAdapter } from '../core/adapter.js';
 import { Response, Schema, ToolWrapper, toSdkPagination } from '../core/helper.js';
+import { lean } from '../core/lean.js';
 import { createLogger } from '../core/logger.js';
 
 const log = createLogger('MCP:Tool:project-commands');
@@ -128,13 +129,14 @@ export function registerProject(adapter: McpAdapter): void {
       description: 'Get information of upsun project',
       inputSchema: {
         project_id: Schema.projectId(),
+        full: Schema.full(),
       },
     },
-    ToolWrapper.trace('info-project', async ({ project_id }) => {
+    ToolWrapper.trace('info-project', async ({ project_id, full }) => {
       log.debug(`Get Information of Project: ${project_id}`);
       const result = await adapter.client.projects.info(project_id);
 
-      return Response.json(result);
+      return Response.json(full ? result : lean(result));
     })
   );
 
@@ -156,18 +158,19 @@ export function registerProject(adapter: McpAdapter): void {
       inputSchema: {
         organization_id: Schema.organizationId(),
         ...Schema.pagination(),
+        full: Schema.full(),
       },
     },
     ToolWrapper.traceWithMetrics(
       'list-project',
-      async ({ organization_id, page_size, page_link }) => {
+      async ({ organization_id, page_size, page_link, full }) => {
         log.debug(`List all my projects in Organization: ${organization_id}`);
         const result = await adapter.client.projects.list(
           organization_id,
           toSdkPagination({ page_size, page_link })
         );
 
-        return Response.json(result);
+        return Response.json(full ? result : lean(result, { itemsKey: 'items' }));
       },
       result => ({
         'result.has_content': !!result,

--- a/upsun-mcp/src/core/helper.ts
+++ b/upsun-mcp/src/core/helper.ts
@@ -120,6 +120,22 @@ export class Schema {
   }
 
   /**
+   * Creates a Zod boolean schema for the lean-output opt-out flag. Read tools
+   * return a projected, token-lean payload by default; passing `full: true`
+   * returns the raw API response (full HAL, all fields).
+   *
+   * @returns An optional Zod boolean schema for the `full` flag.
+   */
+  static full(): z.ZodOptional<z.ZodBoolean> {
+    return z
+      .boolean()
+      .optional()
+      .describe(
+        'Return the full raw API response instead of the lean projected output. Defaults to false (lean).'
+      );
+  }
+
+  /**
    * Returns the Zod schema fields for pagination parameters supported by the
    * Upsun API. To follow a next/previous page, pass `links.next.href` or
    * `links.previous.href` from the previous response as `page_link`.

--- a/upsun-mcp/src/core/lean.ts
+++ b/upsun-mcp/src/core/lean.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Lean output for read tools (MR1).
+ *
+ * The Upsun API returns raw HAL: every resource carries a `_links` block
+ * (~28 entries on an environment) and sometimes an `_embedded` block. An MCP
+ * client invokes actions by tool name, not by following hypermedia links, so
+ * that envelope is dead weight it pays for in context tokens. Stripping it from
+ * an environment list cuts ~68% of the payload.
+ *
+ * This is a denylist, not an allowlist: we remove the two HAL keys and pass
+ * everything else through. New API fields appear automatically, and there is
+ * nothing per-resource to maintain — the rule is global to every read tool.
+ *
+ * One thing must survive: pagination. Some list endpoints return their
+ * next/previous page cursor in the response *envelope* (the wrapper around the
+ * items array), and the tools instruct the agent to follow `links.next.href`.
+ * So the HAL keys are stripped only from resource objects — list items and
+ * single `info`/`get` results — never from the list envelope. Callers opt back
+ * into the raw payload with `full: true`.
+ */
+
+/** HAL keys removed from every resource object. */
+const HAL_KEYS = new Set(['_links', '_embedded']);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Return a shallow copy of a resource object with the HAL keys removed. Every
+ * other field passes through untouched. Non-objects are returned as-is.
+ */
+function stripHal(value: unknown): unknown {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    if (!HAL_KEYS.has(key)) {
+      out[key] = value[key];
+    }
+  }
+  return out;
+}
+
+/**
+ * Options controlling how {@link lean} interprets the payload shape.
+ */
+export interface LeanOptions {
+  /**
+   * For an enveloped list (e.g. `{count, items, facets, links}`), the key
+   * holding the resource array. The envelope itself — including its pagination
+   * `links`/`_links` — is preserved; only the items are stripped. Omit for
+   * bare-array or single-object payloads.
+   */
+  itemsKey?: string;
+}
+
+/**
+ * Strip the HAL envelope from a read-tool payload. Handles the three shapes the
+ * read tools return:
+ *
+ *  - bare array of resources → each item stripped;
+ *  - enveloped list (`opts.itemsKey`) → envelope kept (pagination intact), items stripped;
+ *  - single resource object → stripped.
+ *
+ * Returns the input unchanged for null/undefined or unrecognized shapes, so the
+ * result can always go straight to `Response.json`.
+ *
+ * @param data - The raw API result.
+ * @param opts - Shape hints (e.g. `itemsKey` for enveloped lists).
+ */
+export function lean(data: unknown, opts: LeanOptions = {}): unknown {
+  if (data == null) {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(stripHal);
+  }
+
+  if (opts.itemsKey) {
+    const envelope = data as Record<string, unknown>;
+    const inner = envelope[opts.itemsKey];
+    if (Array.isArray(inner)) {
+      return { ...envelope, [opts.itemsKey]: inner.map(stripHal) };
+    }
+    return data;
+  }
+
+  if (isPlainObject(data)) {
+    return stripHal(data);
+  }
+
+  return data;
+}

--- a/upsun-mcp/test/command/activity.test.ts
+++ b/upsun-mcp/test/command/activity.test.ts
@@ -220,11 +220,12 @@ describe('Activity Command Module', () => {
       registerActivity(mockAdapter);
     });
 
-    it('should get activity details successfully', async () => {
+    it('should return the full raw activity with full:true', async () => {
       const callback = toolCallbacks['get-activity'];
       const params = {
         project_id: 'test-project-13',
         activity_id: 'test-activity-123',
+        full: true,
       };
 
       const result = await callback(params);
@@ -263,10 +264,11 @@ describe('Activity Command Module', () => {
       registerActivity(mockAdapter);
     });
 
-    it('should list activities successfully', async () => {
+    it('should return the full raw list with full:true', async () => {
       const callback = toolCallbacks['list-activity'];
       const params = {
         project_id: 'test-project-13',
+        full: true,
       };
 
       const result = await callback(params);
@@ -433,6 +435,7 @@ describe('Activity Command Module', () => {
       const params = {
         project_id: 'test-project-13',
         activity_id: 'test-activity-123',
+        full: true,
       };
 
       const result = await callback(params);

--- a/upsun-mcp/test/command/environment.test.ts
+++ b/upsun-mcp/test/command/environment.test.ts
@@ -248,11 +248,12 @@ describe('Environment Command Module', () => {
       registerEnvironment(mockAdapter);
     });
 
-    it('should get environment info successfully', async () => {
+    it('should return the full raw payload with full:true', async () => {
       const callback = toolCallbacks['info-environment'];
       const params = {
         project_id: 'test-project-13',
         environment_name: 'main',
+        full: true,
       };
 
       const result = await callback(params);
@@ -287,10 +288,11 @@ describe('Environment Command Module', () => {
       registerEnvironment(mockAdapter);
     });
 
-    it('should list environments successfully', async () => {
+    it('should return the full raw list with full:true', async () => {
       const callback = toolCallbacks['list-environment'];
       const params = {
         project_id: 'test-project-13',
+        full: true,
       };
 
       const result = await callback(params);

--- a/upsun-mcp/test/core/lean.test.ts
+++ b/upsun-mcp/test/core/lean.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from '@jest/globals';
+import { lean } from '../../src/core/lean';
+
+/**
+ * Behavioral gate for MR1 lean output (denylist).
+ *
+ * The contract is deliberately narrow: strip the HAL envelope (`_links`,
+ * `_embedded`) from resource objects, pass every other field through, and never
+ * touch a list envelope — because some list endpoints carry their pagination
+ * cursor (`links.next`/`previous`) there and the tools instruct the agent to
+ * follow it. These assertions pin exactly that, so a new API field rides through
+ * untouched while a regression that drops pagination or leaks `_links` fails.
+ */
+
+// Bare-array list, as `environments.list()` / `activities.list()` return: each
+// item carries the HAL `_links` block; there is no envelope.
+const rawEnvironmentList = [
+  {
+    id: 'main',
+    name: 'main',
+    machine_name: 'main-abc123',
+    type: 'production',
+    status: 'active',
+    created_at: '2025-05-28T00:00:00Z',
+    has_staged_activities: false,
+    _links: { self: { href: '/x' }, ssh: { href: 'ssh://x' }, '#activities': { href: '/a' } },
+    _embedded: { foo: 'bar' },
+  },
+];
+
+// Enveloped list, as `projects.list()` returns: pagination lives on the envelope
+// under `links`; the items themselves have no `_links`.
+const rawProjectList = {
+  count: 1,
+  items: [{ id: 'prj0000000001', title: 'Site', status: 'active', region: 'eu-5.platform.sh' }],
+  facets: { count: 1 },
+  links: { self: { href: '/projects' }, next: { href: '/projects?page=2' } },
+};
+
+// Hypothetical envelope whose pagination cursor sits under `_links` (the case
+// the maintainer flagged). The strip must leave the envelope alone.
+const rawEnvelopeHalLinks = {
+  count: 1,
+  items: [{ id: 'a', _links: { self: { href: '/a' } } }],
+  _links: { self: { href: '/list' }, next: { href: '/list?page=2' } },
+};
+
+// Single resource, as `info()` / `get()` return.
+const rawEnvironment = {
+  id: 'main',
+  name: 'main',
+  status: 'active',
+  _links: { self: { href: '/x' } },
+  _embedded: { settings: {} },
+};
+
+describe('lean (MR1 denylist)', () => {
+  describe('strips the HAL envelope from resource objects', () => {
+    it('drops _links and _embedded from each list item', () => {
+      const out = lean(rawEnvironmentList) as Array<Record<string, unknown>>;
+      expect(out[0]).not.toHaveProperty('_links');
+      expect(out[0]).not.toHaveProperty('_embedded');
+    });
+
+    it('drops _links and _embedded from a single resource', () => {
+      const out = lean(rawEnvironment) as Record<string, unknown>;
+      expect(out).not.toHaveProperty('_links');
+      expect(out).not.toHaveProperty('_embedded');
+    });
+  });
+
+  describe('passes every non-HAL field through (denylist, not allowlist)', () => {
+    it('keeps an arbitrary field the API may add without a code change', () => {
+      const out = lean(rawEnvironmentList) as Array<Record<string, unknown>>;
+      // has_staged_activities is not "curated" — a denylist keeps it for free.
+      expect(out[0]).toHaveProperty('has_staged_activities', false);
+      expect(out[0]).toHaveProperty('machine_name', 'main-abc123');
+      expect(out[0]).toHaveProperty('created_at', '2025-05-28T00:00:00Z');
+    });
+
+    it('output keys are exactly the input keys minus the HAL keys', () => {
+      const out = lean(rawEnvironment) as Record<string, unknown>;
+      expect(Object.keys(out).sort()).toEqual(['id', 'name', 'status']);
+    });
+  });
+
+  describe('preserves the list envelope so pagination survives', () => {
+    it('keeps envelope `links.next` and trims items (links under `links`)', () => {
+      const out = lean(rawProjectList, { itemsKey: 'items' }) as Record<string, unknown>;
+      expect(out).toHaveProperty('count', 1);
+      expect(out).toHaveProperty('facets');
+      expect((out.links as any).next.href).toBe('/projects?page=2');
+    });
+
+    it('keeps an envelope-level `_links` cursor untouched', () => {
+      const out = lean(rawEnvelopeHalLinks, { itemsKey: 'items' }) as Record<string, unknown>;
+      // Envelope `_links` is pagination — must survive.
+      expect((out._links as any).next.href).toBe('/list?page=2');
+      // But the item's own `_links` is stripped.
+      const item = (out.items as Array<Record<string, unknown>>)[0];
+      expect(item).not.toHaveProperty('_links');
+      expect(item).toHaveProperty('id', 'a');
+    });
+  });
+
+  describe('shape and safety', () => {
+    it('passes null/undefined through unchanged', () => {
+      expect(lean(null)).toBeNull();
+      expect(lean(undefined)).toBeUndefined();
+    });
+
+    it('leaves a string array (e.g. plain URLs) untouched', () => {
+      const urls = ['https://a.example.com', 'https://b.example.com'];
+      expect(lean(urls)).toEqual(urls);
+    });
+
+    it('does not mutate its input', () => {
+      const snapshot = JSON.stringify(rawEnvironmentList);
+      lean(rawEnvironmentList);
+      expect(JSON.stringify(rawEnvironmentList)).toBe(snapshot);
+    });
+  });
+});


### PR DESCRIPTION
## What

Read tools strip the HAL envelope (`_links`/`_embedded`) from resource objects by default. A `full: true` flag returns the raw payload unchanged.

Tools: `list-environment`, `info-environment`, `urls-environment`, `list-project`, `info-project`, `list-activity`, `get-activity`.

## Why

The Upsun API returns raw HAL. Every list item carries a `_links` block (~28 entries on an environment) that an MCP client never follows — it invokes actions by tool name. The agent pays for every byte in context tokens.

Measured against real fixtures (308 environments, offline replay through the real handlers):

| tool | full | lean | reduction |
|---|---|---|---|
| **list-environment** | 2,206,864 | 697,527 | **−68.4%** |
| urls-environment | 1,953 | 1,583 | −18.9% |
| list-activity | 192,775 | 183,830 | −4.6% |
| list-project | 56,199 | 56,199 | 0% |
| info-environment / info-project | — | — | ~0% |

The win concentrates in `list-environment` — which was ~89% of the token cost across all read tools, so a 68% cut there is the bulk of the benefit. Tools whose payload is light on `_links` (project list has none; activity bloat is `log`/`payload`, not HAL) see little change.

## Approach: denylist, not allowlist

Earlier revision used a per-resource field **allowlist** (kept named fields, dropped the rest). It hit ~87.5% but required curating a field list per resource and maintaining it against API changes. Per review (thanks @Mickael, @pjcdawkins), switched to a **denylist**: remove the two HAL keys, pass everything else through.

- **Less maintenance.** New API fields appear automatically; nothing per-resource to keep in sync.
- **Pagination-safe.** Some list endpoints return their next/previous cursor in the response *envelope*, and the tools instruct the agent to follow `links.next.href`. The strip only touches resource objects (list items, single `info`/`get` results) and never the envelope, so pagination keeps working in the default response — confirmed for both `links` and `_links` envelope cursors.

## Backward compatibility

`full` is optional, default `false`. `full: true` returns the exact prior payload. No breaking change.

## Tests

`test/core/lean.test.ts` pins the contract: HAL keys stripped from resource objects, every other field passes through (denylist, not allowlist), and the list envelope — including pagination cursors under `links` and `_links` — is preserved. Build clean, lint clean, full suite green.

## Possible follow-up

If we want some of the activity reduction back without reintroducing per-resource curation, we could add a few known-heavy keys (`log`, `payload`, `text`, `commands`, `timings`) to the same global denylist. Still fail-open, still global. Out of scope here; noting for the record.