### PR TITLE
fix(scripts): repair watch entry path, drop dead coverage:verify

### DIFF
--- a/upsun-mcp/package.json
+++ b/upsun-mcp/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf build",
     "run": "node build/index.js",
     "build": "tsc --noEmit && tsc -p tsconfig.json",
-    "watch": "tsx watch index.ts",
+    "watch": "tsx watch src/index.ts",
     "inspector": "npx @modelcontextprotocol/inspector http://localhost:3000 --header 'upsun-api-token: xxxx'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -24,8 +24,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:ci": "NODE_OPTIONS=--experimental-vm-modules jest --ci --watchAll=false --passWithNoTests",
     "coverage:report": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --coverageReporters=text-lcov | coveralls",
-    "coverage:check": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --passWithNoTests",
-    "coverage:verify": "./scripts/check-coverage.sh"
+    "coverage:check": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --passWithNoTests"
   },
   "files": [
     "build"


### PR DESCRIPTION
## What

Two `package.json` scripts were broken:

- `watch` ran `tsx watch index.ts`. That file does not exist. The entry point is `src/index.ts`.
- `coverage:verify` called `scripts/check-coverage.sh`. The script was never committed.

## Fix

- Point `watch` at `src/index.ts`.
- Delete `coverage:verify`. `coverage:check` already enforces the thresholds defined in `jest.config.ts` (global plus per-folder overrides), so the entry was redundant even if the shell script existed.

## Verification

Ran `npm run watch` on this branch. The server compiles and boots (telemetry, config, and startup logs appear; process stays up and watches for changes).

## Merge order

Merge this before #28. That PR removes the broken-scripts warning from CLAUDE.md, which only becomes true once this lands.