### PR TITLE
fix(gateway): drain transports on SIGTERM, exit on unhandled faults

### DIFF
--- a/upsun-mcp/src/core/gateway.ts
+++ b/upsun-mcp/src/core/gateway.ts
@@ -243,8 +243,8 @@ export class GatewayServer<A extends McpAdapter> {
    * Starts the HTTP server and begins listening for connections.
    *
    * Binds the server to all available network interfaces (0.0.0.0) and displays
-   * configuration information for both transport types. Sets up proper shutdown
-   * handling to clean up active transport sessions.
+   * configuration information for both transport types. Session cleanup lives in
+   * {@link GatewayServer.shutdown}, which the signal handlers in `index.ts` call.
    *
    * @param port - Port number to listen on (default: 3000)
    *
@@ -283,18 +283,6 @@ SUPPORTED TRANSPORT OPTIONS:
 `);
     });
 
-    // Handle server shutdown
-    process.on('SIGINT', async () => {
-      coreLog.info('Shutting down server...');
-
-      // Close all active transports to properly clean up resources
-      await this.sseTransport.closeAllSessions();
-      await this.httpTransport.closeAllSessions();
-
-      coreLog.info('Server shutdown complete');
-      process.exit(0);
-    });
-
     process.on('uncaughtException', error => {
       coreLog.error('Uncaught Exception:', error);
     });
@@ -302,5 +290,20 @@ SUPPORTED TRANSPORT OPTIONS:
     process.on('unhandledRejection', (reason, promise) => {
       coreLog.error('Unhandled Rejection at:', promise, 'reason:', reason);
     });
+  }
+
+  /**
+   * Closes every active session on both transports.
+   *
+   * Does not exit the process — the signal handlers in `index.ts` own that, so
+   * SIGTERM and SIGINT run the same shutdown steps in the same order.
+   *
+   * @returns Promise that resolves once both transports are drained
+   */
+  public async shutdown(): Promise<void> {
+    coreLog.info('Closing active transport sessions...');
+    await this.sseTransport.closeAllSessions();
+    await this.httpTransport.closeAllSessions();
+    coreLog.info('Transport sessions closed');
   }
 }

--- a/upsun-mcp/src/core/gateway.ts
+++ b/upsun-mcp/src/core/gateway.ts
@@ -283,12 +283,17 @@ SUPPORTED TRANSPORT OPTIONS:
 `);
     });
 
+    // Both handlers exit. Registering a listener for either event overrides Node's
+    // default crash, which left the server running on corrupted state. Upsun's
+    // supervisor restarts the process, so exiting is the shorter outage.
     process.on('uncaughtException', error => {
       coreLog.error('Uncaught Exception:', error);
+      process.exit(1);
     });
 
     process.on('unhandledRejection', (reason, promise) => {
       coreLog.error('Unhandled Rejection at:', promise, 'reason:', reason);
+      process.exit(1);
     });
   }
 

--- a/upsun-mcp/src/index.ts
+++ b/upsun-mcp/src/index.ts
@@ -15,10 +15,26 @@ await initTelemetry();
 log.info('Starting Upsun MCP Server...');
 log.debug(getConfigSummary());
 
-// Handle graceful shutdown
+// Set below in remote mode. Holds the transport sessions the shutdown path drains.
+let gateway: GatewayServer<UpsunMcpServer> | undefined;
+
+// Handle graceful shutdown. Upsun sends SIGTERM on deploy and on stop; SIGINT
+// comes from a local Ctrl-C. Both run this one path, so sessions close before
+// telemetry flushes and the process exits once.
+// Each step is guarded on its own: a throw must not skip the next step or the exit.
 const cleanup = async (): Promise<void> => {
   log.info('Shutting down gracefully...');
-  await shutdownTelemetry();
+  try {
+    await gateway?.shutdown();
+  } catch (error) {
+    log.error('Failed to close transport sessions:', error);
+  }
+  try {
+    await shutdownTelemetry();
+  } catch (error) {
+    log.error('Failed to shut down telemetry:', error);
+  }
+  log.info('Shutdown complete');
   process.exit(0);
 };
 
@@ -34,7 +50,7 @@ if (appConfig.typeEnv === McpType.LOCAL) {
 } else {
   // SSE & Streamable
   const PORT = appConfig.port;
-  const srv = new GatewayServer(UpsunMcpServer);
-  await srv.listen(PORT);
+  gateway = new GatewayServer(UpsunMcpServer);
+  await gateway.listen(PORT);
   log.info(`Gateway server started on port ${PORT}`);
 }

--- a/upsun-mcp/test/core/gateway.test.ts
+++ b/upsun-mcp/test/core/gateway.test.ts
@@ -63,8 +63,19 @@ describe('GatewayServer', () => {
   let gatewayServer: GatewayServer<McpAdapter>;
   let mockAdapterFactory: jest.MockedClass<typeof McpAdapter>;
 
+  /** Process events listen() attaches to. Tracked so tests can restore them. */
+  const CRASH_EVENTS = ['uncaughtException', 'unhandledRejection'] as const;
+  let listenersBefore: Record<string, ((...args: any[]) => void)[]>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // listen() registers process-level handlers. Snapshot them so afterEach can
+    // detach the ones this test added; leaking an exit(1) handler would kill the
+    // Jest worker on any later stray rejection.
+    listenersBefore = Object.fromEntries(
+      CRASH_EVENTS.map(event => [event, process.listeners(event)])
+    );
 
     // Mock the adapter factory
     mockAdapterFactory = jest.fn().mockImplementation(() => ({
@@ -75,6 +86,23 @@ describe('GatewayServer', () => {
     // Create server instance
     gatewayServer = new GatewayServer(mockAdapterFactory);
   });
+
+  afterEach(() => {
+    for (const event of CRASH_EVENTS) {
+      for (const listener of process.listeners(event)) {
+        if (!listenersBefore[event].includes(listener)) {
+          process.off(event, listener);
+        }
+      }
+    }
+  });
+
+  /** Runs listen() with a stubbed http server and returns the handlers it added. */
+  const listenAndCollect = (event: string): ((...args: any[]) => void)[] => {
+    gatewayServer.app.listen = jest.fn().mockReturnValue({ close: jest.fn() });
+    gatewayServer.listen();
+    return process.listeners(event).filter(l => !listenersBefore[event].includes(l));
+  };
 
   describe('constructor', () => {
     it('should initialize the Express app and transports', () => {
@@ -145,10 +173,22 @@ describe('GatewayServer', () => {
     it('should not register signal handlers of its own', () => {
       const before = process.listenerCount('SIGTERM') + process.listenerCount('SIGINT');
 
-      gatewayServer.app.listen = jest.fn().mockReturnValue({ close: jest.fn() });
-      gatewayServer.listen();
+      listenAndCollect('uncaughtException');
 
       expect(process.listenerCount('SIGTERM') + process.listenerCount('SIGINT')).toBe(before);
+    });
+  });
+
+  describe('crash handlers', () => {
+    it.each(CRASH_EVENTS)('should exit 1 on %s', event => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      const handlers = listenAndCollect(event);
+      expect(handlers).toHaveLength(1);
+      handlers[0](new Error('boom'), Promise.resolve());
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
     });
   });
 

--- a/upsun-mcp/test/core/gateway.test.ts
+++ b/upsun-mcp/test/core/gateway.test.ts
@@ -131,6 +131,27 @@ describe('GatewayServer', () => {
     });
   });
 
+  describe('shutdown method', () => {
+    it('should close sessions on both transports', async () => {
+      gatewayServer.sseTransport.closeAllSessions = jest.fn().mockResolvedValue(undefined);
+      gatewayServer.httpTransport.closeAllSessions = jest.fn().mockResolvedValue(undefined);
+
+      await gatewayServer.shutdown();
+
+      expect(gatewayServer.sseTransport.closeAllSessions).toHaveBeenCalled();
+      expect(gatewayServer.httpTransport.closeAllSessions).toHaveBeenCalled();
+    });
+
+    it('should not register signal handlers of its own', () => {
+      const before = process.listenerCount('SIGTERM') + process.listenerCount('SIGINT');
+
+      gatewayServer.app.listen = jest.fn().mockReturnValue({ close: jest.fn() });
+      gatewayServer.listen();
+
+      expect(process.listenerCount('SIGTERM') + process.listenerCount('SIGINT')).toBe(before);
+    });
+  });
+
   describe('error handling', () => {
     it('should be properly initialized without throwing errors', () => {
       // The constructor sets up error handlers and runs without throwing


### PR DESCRIPTION
Two process-lifecycle bugs in `gateway.ts`. Both are in the same 18-line block, so they ship together as two commits — either can be dropped.

## 1. SIGTERM never closed transport sessions

Upsun sends SIGTERM on deploy and on stop. Handler coverage before this PR:

| Signal | `index.ts` handler (flush telemetry) | `gateway.ts` handler (close transports) |
|---|---|---|
| SIGTERM | runs | **never runs** |
| SIGINT (local Ctrl-C) | runs | runs — **both**, each calling `process.exit(0)` |

So production never closed active SSE or Streamable HTTP sessions. Locally, the two SIGINT handlers raced: whichever finished its async work first exited the process and truncated the other.

`GatewayServer.shutdown()` now drains both transports and returns. The signal handlers in `index.ts` own the ordering and the exit, so SIGTERM and SIGINT run identical steps. Each step is guarded on its own — `shutdownTelemetry()` rethrows on failure, which previously escaped the handler and left the process hanging until SIGKILL.

Measured on the built server (`node build/index.js`, then `kill -TERM`):

| | `main` | this branch |
|---|---|---|
| log output | `Shutting down gracefully...` | `Shutting down gracefully...`<br>`Closing active transport sessions...`<br>`Transport sessions closed`<br>`Shutdown complete` |
| exit code | 0 | 0 |

## 2. Unhandled faults left the server running

Registering a listener for `uncaughtException` or `unhandledRejection` overrides Node's default crash. The existing handlers only logged. For rejections that is a behavior change Node made in v15 — unhandled rejections terminate the process unless something suppresses them, and this suppressed them.

Both handlers now `process.exit(1)`. Upsun's supervisor restarts the process (docs: "restarted if ever terminated") and `.upsun/config.yaml` runs `node build/index.js` directly under it, so a restart is a shorter outage than an unbounded broken state. Neither handler drains transports first: the state that made them fire is the state not to run more async work on.

Measured by booting the built `GatewayServer` and triggering each fault:

| Fault | `main` | this branch |
|---|---|---|
| `unhandledRejection` | still serving after 2s | exit 1 |
| `uncaughtException` | still serving after 2s | exit 1 |

## Tests

`test/core/gateway.test.ts` gains 3 cases (487 -> 489, all green):

- `shutdown()` closes sessions on both transports
- `listen()` registers no signal handlers of its own — this fails on `main`
- each crash handler exits 1 (`it.each`)

The old SIGINT block had no test. `afterEach` detaches handlers `listen()` added, so an `exit(1)` handler cannot leak into a later test and kill the Jest worker.

## Checks

- `npm run build` clean
- `npm test` 489 passed, 26 suites
- `npm run lint` clean
- `npx prettier --check` clean on all three changed files

No tool output changes, so no benchmark run.